### PR TITLE
Migrate the run of Parser to GitHub Action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
           # checkout@v2 doesn't pull tags by default now, which results in super long auto changelog, so pull all history incl. tags
           # alternative would be to use checkout@v1
           fetch-depth: 0
-          lfs: 'true'
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           # alternative would be to use checkout@v1
 
       - name: fetch latest 200 commits & tags
-        run: git fetch --tags --depth=200
+        run: git fetch --depth=200
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
 
   release-linux:
     runs-on: ubuntu-latest
+    needs: build-windows
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,20 +17,23 @@ on:
 jobs:
   build-windows:
     runs-on: windows-latest
-    
+    strategy:
+      matrix:
+        version: [Retail, Classic, PTR, BETA] # 在此設定不同的版本
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Database Parser
         run: |
           cd .contrib/Parser
-          Parser for Retail.bat
-          cd ../../
+          "Parser for ${{ matrix.version }}".bat
         shell: cmd
+      
       - uses: actions/upload-artifact@v4
         with:
-            name: Retail-db-output  # Artifact name
-            path: db/Retail/  # File path to upload
+            name: ${{ matrix.version }}-db-output  # 使用 matrix 版本作為 artifact 名稱
+            path: db/${{ matrix.version }}/  # 文件路徑動態化
             retention-days: 1
 
   release-linux:
@@ -44,11 +47,11 @@ jobs:
         run: |
           git fetch origin --deepen=200
 
-      - name: Download artifact
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: Retail-db-output  # Name of the artifact to download
-          path: db/Retail
+          name: ${{ matrix.version }}-db-output  # 根據 matrix 版本下載相應的 artifact
+          path: db/${{ matrix.version }}
 
       # once cloned, we just run the GitHub Action for the packager project
       - name: Package and release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           Parser for Retail.bat
           cd ../../
         shell: cmd
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
             name: Retail-db-output  # Artifact name
             path: db/Retail/  # File path to upload
@@ -49,7 +49,7 @@ jobs:
           rm -rf db/Retail
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Retail-db-output  # Name of the artifact to download
           path: db/Retail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-          # checkout@v2 doesn't pull tags by default now, which results in super long auto changelog, so pull all history incl. tags
-          # alternative would be to use checkout@v1
-
-      - name: fetch latest 200 commits & tags
-        run: git fetch --depth=200
+        with:
+          fetch-depth: 200
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,7 @@ jobs:
           # alternative would be to use checkout@v1
 
       - name: fetch latest 200 commits & tags
-        run: |
-          git fetch --depth=200
-          git fetch --tags --depth=200
+        run: git fetch --tags --depth=200
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,23 +17,26 @@ on:
 jobs:
   build-windows:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        version: [Retail, Classic, PTR, BETA] # 在此設定不同的版本
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Database Parser
+      - name: Database Parser for Retail
         run: |
           cd .contrib/Parser
-          "Parser for ${{ matrix.version }}".bat
+          "Parser for Retail".bat
         shell: cmd
-      
+
+      - name: Database Parser for Classic
+        run: |
+          cd .contrib/Parser
+          "Parser for Classic".bat
+        shell: cmd
+
       - uses: actions/upload-artifact@v4
         with:
-            name: ${{ matrix.version }}-db-output  # 使用 matrix 版本作為 artifact 名稱
-            path: db/${{ matrix.version }}/  # 文件路徑動態化
+            name: db-output  # Artifact name
+            path: db/  # File path to upload
             retention-days: 1
 
   release-linux:
@@ -50,8 +53,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.version }}-db-output  # 根據 matrix 版本下載相應的 artifact
-          path: db/${{ matrix.version }}
+          name: db-output  # Name of the artifact to download
+          path: db
 
       # once cloned, we just run the GitHub Action for the packager project
       - name: Package and release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
           # checkout@v2 doesn't pull tags by default now, which results in super long auto changelog, so pull all history incl. tags
           # alternative would be to use checkout@v1
-          fetch-depth: 0
+
+      - name: fetch latest 200 commits & tags
+        run: |
+          git fetch --depth=200
+          git fetch --tags --depth=200
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  build-windows:
+    runs-on: windows-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Database Parser
+        run: |
+          cd .contrib/Parser
+          Parser for Retail.bat
+          cd ../../
+        shell: cmd
+      - uses: actions/upload-artifact@v3
+        with:
+            name: Retail-db-output  # Artifact name
+            path: db/Retail/  # File path to upload
+            retention-days: 1
+
+  release-linux:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +43,16 @@ jobs:
           # alternative would be to use checkout@v1
           fetch-depth: 0
           lfs: 'true'
+
+      - name: Delete all files in db/Retail directory
+        run: |
+          rm -rf db/Retail
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Retail-db-output  # Name of the artifact to download
+          path: db/Retail
 
       # once cloned, we just run the GitHub Action for the packager project
       - name: Package and release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           fetch-depth: 200
 
+      - name: Fetch tags
+        run: git fetch --tags
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,15 @@ jobs:
         with:
           fetch-depth: 200
 
-      - name: Fetch tags
-        run: git fetch --tags
+      - name: Fetch the latest two tags
+        run: |
+          # Get the latest 2 tags from the remote
+          latest_two_tags=$(git ls-remote --tags --sort='-v:refname' origin | head -n 2 | awk '{print $2}')
+          
+          # Fetch each of these tags
+          for tag in $latest_two_tags; do
+              git fetch origin "$tag:$tag"
+          done
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 200
 
-      - name: Fetch the latest two tags
+      - name: Fetch 200 latest commits and tags
         run: |
-          # Get the latest 2 tags from the remote
-          latest_two_tags=$(git ls-remote --tags --sort='-v:refname' origin | head -n 2 | awk '{print $2}')
-          
-          # Fetch each of these tags
-          for tag in $latest_two_tags; do
-              git fetch origin "$tag:$tag"
-          done
+          git fetch origin --deepen=200
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,6 @@ jobs:
           fetch-depth: 0
           lfs: 'true'
 
-      - name: Delete all files in db/Retail directory
-        run: |
-          rm -rf db/Retail
-
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This patch contains the following changes:
1. Divide the original GitHub release flow into two parts, build-windows & release-linux.
2. Build-windows runs the two flavors of Parser and uploads the results as artifacts.
3. Release-linux will download the artifacts and run the addon package & release process.
4. Release will only fetch the latest 200 commits now. (by [Molkree](https://github.com/ATTWoWAddon/AllTheThings/commits?author=Molkree))