### PR TITLE
[Localization] Use savedInstanceID to localize all of dungeons in Classic Era/SoD.

### DIFF
--- a/.contrib/Parser/DATAS/00 - DB/InstanceDB.lua
+++ b/.contrib/Parser/DATAS/00 - DB/InstanceDB.lua
@@ -31,7 +31,11 @@ inst(72, 671);	-- The Bastion of Twilight
 inst(73, 669);	-- Blackwing Descent
 inst(74, 754);	-- Throne of the Four Winds
 inst(75, 757);	-- Baradin Hold
+-- #if BEFORE CATA
+inst(76, 309);	-- Zul'Gurub
+-- #else
 inst(76, 859);	-- Zul'Gurub
+-- #endif
 inst(77, 568);	-- Zul'Aman
 inst(78, 720);	-- Firelands
 inst(184, 938);	-- End Time
@@ -53,7 +57,11 @@ inst(238, 34);	-- The Stockade
 inst(239, 70);	-- Uldaman
 inst(240, 43);	-- Wailing Caverns
 inst(241, 209);	-- Zul'Farrak
+-- #if BEFORE MOP
+inst(246, 289);	-- Scholomance
+-- #else
 inst(246, 1007);	-- Scholomance
+-- #endif
 inst(247, 558);	-- Auchenai Crypts
 inst(248, 543);	-- Hellfire Ramparts
 inst(249, 585);	-- Magisters' Terrace
@@ -91,7 +99,11 @@ inst(303, 962);	-- Gate of the Setting Sun
 inst(311, 1001);	-- Scarlet Halls
 inst(312, 959);	-- Shado-Pan Monastery
 inst(313, 960);	-- Temple of the Jade Serpent
+-- #if BEFORE MOP
+inst(316, 189);	-- Scarlet Monastery
+-- #else
 inst(316, 1004);	-- Scarlet Monastery
+-- #endif
 inst(317, 1008);	-- Mogu'shan Vaults
 inst(320, 996);	-- Terrace of Endless Spring
 inst(321, 994);	-- Mogu'shan Palace

--- a/.contrib/Parser/DATAS/00 - DB/InstanceDB.lua
+++ b/.contrib/Parser/DATAS/00 - DB/InstanceDB.lua
@@ -14,6 +14,8 @@ end
 inst(2789, 2789);	-- The Tainted Scar
 inst(2791, 2791);	-- Storm Cliffs
 inst(2784, 2784);	-- Demon Fall Canyon
+inst(2804, 2804);	-- The Crystal Vale
+inst(2832, 2832);	-- Nightmare Grove
 -- #endif
 
 -- This list was exported using excel manually using data from this url:

--- a/.contrib/Parser/DATAS/00 - DB/InstanceDB.lua
+++ b/.contrib/Parser/DATAS/00 - DB/InstanceDB.lua
@@ -17,7 +17,7 @@ inst(2784, 2784);	-- Demon Fall Canyon
 -- #endif
 
 -- This list was exported using excel manually using data from this url:
--- https://wago.tools/db2/JournalInstance?build=11.0.0.55120
+-- https://wago.tools/db2/JournalInstance?build=11.0.7.58238
 inst(63, 36);	-- Deadmines
 inst(64, 33);	-- Shadowfang Keep
 inst(65, 643);	-- Throne of the Tides
@@ -42,12 +42,12 @@ inst(226, 389);	-- Ragefire Chasm
 inst(227, 48);	-- Blackfathom Deeps
 inst(228, 230);	-- Blackrock Depths
 inst(229, 229);	-- Lower Blackrock Spire
-inst(230, 429);	-- Dire Maul
+inst(230, 429);	-- Dire Maul - Capital Gardens
 inst(231, 90);	-- Gnomeregan
 inst(232, 349);	-- Maraudon
 inst(233, 129);	-- Razorfen Downs
 inst(234, 47);	-- Razorfen Kraul
-inst(236, 329);	-- Stratholme
+inst(236, 329);	-- Stratholme - Main Gate
 inst(237, 109);	-- The Temple of Atal'hakkar
 inst(238, 34);	-- The Stockade
 inst(239, 70);	-- Uldaman
@@ -193,7 +193,7 @@ inst(1202, 2521);	-- Ruby Life Pools
 inst(1203, 2515);	-- The Azure Vault
 inst(1204, 2527);	-- Halls of Infusion
 inst(1205, 2574);	-- Dragon Isles
---inst(1206, 0);	-- The Nokud Offensive
+inst(1206, 0);	-- The Nokud Offensive
 inst(1207, 2549);	-- Amirdrassil, the Dream's Hope
 inst(1208, 2569);	-- Aberrus, the Shadowed Crucible
 inst(1209, 2579);	-- Dawn of the Infinite
@@ -206,22 +206,11 @@ inst(1271, 2660);	-- Ara-Kara, City of Echoes
 inst(1272, 2661);	-- Cinderbrew Meadery
 inst(1273, 2657);	-- Nerub-ar Palace
 inst(1274, 2669);	-- City of Threads
+inst(1276, 429);	-- Dire Maul - Warpwood Quarter
+inst(1277, 429);	-- Dire Maul - Gordok Commons
 inst(1278, 2774);	-- Khaz Algar
-inst(1279, 2664);	-- Fungal Folly
-inst(1280, 2679);	-- Mycomancer Cavern
-inst(1281, 2681);	-- Kriegval's Rest
-inst(1282, 2683);	-- The Waterworks
-inst(1283, 2687);	-- The Sinkhole
-inst(1284, 2689);	-- Tak-Rethan Abyss
-inst(1285, 2686);	-- Nightfall Sanctum
-inst(1286, 2690);	-- The Underkeep
-inst(1287, 2680);	-- Earthcrawl Mines
-inst(1288, 2684);	-- The Dread Pit
-inst(1289, 2685);	-- Skittering Breach
-inst(1290, 2688);	-- The Spiral Weave
-inst(1291, 2682);	-- Zekvir's Lair
-inst(1293, 2690);	-- The Underkeep
-inst(1301, 2792);    -- Blackrock Depths
+inst(1292, 329);	-- Stratholme - Service Entrance
+inst(1301, 2792);	-- Blackrock Depths
 
 -- Reassign the instance function
 inst = function(id, t)

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.4 Nightmare Grove.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.4 Nightmare Grove.lua
@@ -4,35 +4,7 @@
 -----------------------------------------------------
 root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, {
 	applyclassicphase(SOD_PHASE_SIX, inst(2832, bubbleDownSelf({["timeline"] = { "added 1.15.5" }}, {	-- Nightmare Grove
-		["npcID"] = createHeader({
-			readable = "Nightmare Grove",
-			text = {
-				en = "Nightmare Grove",
-				es = "Arboleda de la Pesadilla",
-				de = "Alptraumhain",
-				fr = "Bosquet du cauchemar",
-				--it = "",
-				mx = "Arboleda de las Pesadillas",
-				pt = "Bosque do Pesadelo",
-				ru = "Роща Кошмаров",
-				ko = "악몽의 숲",
-				cn = "梦魇林地",
-				tw = "夢魘林地",
-			},
-			description = {
-				en = "Nightmare Grove can be found near the portals to the Emerald Dream.",
-				--[[
-				es = "",
-				de = "",
-				fr = "",
-				it = "",
-				pt = "",
-				ru = "",
-				ko = "",
-				cn = "",
-				]]--
-			},
-		}),
+		["lore"] = "Nightmare Grove can be found near the portals to the Emerald Dream.",
 		["coords"] = {
 			{ 51.2, 10.9, FERALAS },
 			{ 63.3, 27.8, THE_HINTERLANDS },


### PR DESCRIPTION
Originally used 'zone-text-areaID' to get the localized names of all dungeons in Classic Era/SoD.
It's not accurate though, as some unique dungeons in SoD don't have corresponding area names, like [Nightmare Grove](https://github.com/ATTWoWAddon/AllTheThings/blob/37d307a4027cb3489267694bd777ffaa255deb5b/.contrib/Parser/DATAS/01%20-%20Dungeons%20Raids/01%20-%20Classic/2.4%20Nightmare%20Grove.lua#L8).
In this case, custom headers must be used for localization.

World of Warcraft has two ID tables for map information, one is the [UiMap](https://wago.tools/db2/UiMap?build=1.15.6.58185) and the other is the [Map](https://wago.tools/db2/Map?build=1.15.6.58185).
The UiMap is available in all dungeons after the Cata version as the map displayed in Map(M), but before the Cata version, most classic dungeons do not have Map(M) maps.
So in these places, there is no UiMap information in the dungeons.
The MapID information currently used by ATT is the UiMap.
In areas where MapID(UiMap) is provided, ATT will try to use `C_Map.GetMapInfo(UiMapID)` to obtain the localized name as the localized name of the category, this mechanism works well in later flavors of Cata.
But for SoD/Classic Era before Cata, the UiMap in the dungeon does not exist, it can only be localized with area id.

MapID(Map) is an older table, inherited from 1.0.0 to the present, and all dungeons and wild worlds have their MapIDs.
MapID(Map) use `GetRealZoneText(MapID)` to get the localized name.

This change attempts to change the localization of all dungeons in Classic Era/SoD from AreaID to MapID.
The logic of ATT has also been updated, and the zone ID description in Classic dungeon has been deleted to ensure that the localized name will not be obtained through the Zone ID.
