### PR TITLE
[Cata] tag wotlk S5 honor weapons as never available

### DIFF
--- a/.contrib/Parser/DATAS/08 - PvP/03 Wrath of the Lich King PvP Seasons.lua
+++ b/.contrib/Parser/DATAS/08 - PvP/03 Wrath of the Lich King PvP Seasons.lua
@@ -99,44 +99,111 @@ root(ROOTS.PVP, applyclassicphase(WRATH_PHASE_ONE, run(MarkOfWHOOOWHATNow, bubbl
 								{"sub", "pvp_weapons_ensemble", EXPANSION.WRATH, SEASON_DEADLY, PVP_HONOR },
 							},
 						}),
-						i(42557),	-- Savage Gladiator's Barrier
-						i(42511),	-- Savage Gladiator's Baton of Light
-						i(42356),	-- Savage Gladiator's Battle Staff
-						i(42221),	-- Savage Gladiator's Bonecracker
-						i(42295),	-- Savage Gladiator's Bonegrinder
-						i(42212),	-- Savage Gladiator's Chopper
-						i(42206),	-- Savage Gladiator's Cleaver
-						i(42294),	-- Savage Gladiator's Decapitator
-						i(42382),	-- Savage Gladiator's Energy Staff
-						i(42220),	-- Savage Gladiator's Fleshslicer
-						i(44416),	-- Savage Gladiator's Focus Staff
-						i(42344),	-- Savage Gladiator's Gavel
-						i(42297),	-- Savage Gladiator's Greatsword
-						i(42213),	-- Savage Gladiator's Hacker
-						i(42446),	-- Savage Gladiator's Heavy Crossbow
-						i(42445),	-- Savage Gladiator's Longbow
-						i(42215),	-- Savage Gladiator's Mutilator
-						i(42517),	-- Savage Gladiator's Piercing Touch
-						i(42296),	-- Savage Gladiator's Pike
-						i(42222),	-- Savage Gladiator's Pummeler
-						i(42223),	-- Savage Gladiator's Quickblade
-						i(42568),	-- Savage Gladiator's Redoubt
-						i(42447),	-- Savage Gladiator's Rifle
-						i(42218),	-- Savage Gladiator's Ripper
-						i(42216),	-- Savage Gladiator's Shanker
-						i(42556),	-- Savage Gladiator's Shield Wall
-						i(42217),	-- Savage Gladiator's Shiv
-						i(42219),	-- Savage Gladiator's Slasher
-						i(42224),	-- Savage Gladiator's Slicer
-						i(42343),	-- Savage Gladiator's Spellblade
-						i(42388),	-- Savage Gladiator's Staff
-						i(42448),	-- Savage Gladiator's Touch of Defeat
+						-- Savage Gladiator weapons have never been implemented
+						i(42557, {	-- Savage Gladiator's Barrier
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42511, {	-- Savage Gladiator's Baton of Light
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42356, {	-- Savage Gladiator's Battle Staff
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42221, {	-- Savage Gladiator's Bonecracker
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42295, {	-- Savage Gladiator's Bonegrinder
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42212, {	-- Savage Gladiator's Chopper
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42206, {	-- Savage Gladiator's Cleaver
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42294, {	-- Savage Gladiator's Decapitator
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42382, {	-- Savage Gladiator's Energy Staff
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42220, {	-- Savage Gladiator's Fleshslicer
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(44416, {	-- Savage Gladiator's Focus Staff
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42344, {	-- Savage Gladiator's Gavel
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42297, {	-- Savage Gladiator's Greatsword
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42213, {	-- Savage Gladiator's Hacker
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42446, {	-- Savage Gladiator's Heavy Crossbow
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42445, {	-- Savage Gladiator's Longbow
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42215, {	-- Savage Gladiator's Mutilator
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42517, {	-- Savage Gladiator's Piercing Touch
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42296, {	-- Savage Gladiator's Pike
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42222, {	-- Savage Gladiator's Pummeler
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42223, {	-- Savage Gladiator's Quickblade
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42568, {	-- Savage Gladiator's Redoubt
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42447, {	-- Savage Gladiator's Rifle
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42218, {	-- Savage Gladiator's Ripper
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42216, {	-- Savage Gladiator's Shanker
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42556, {	-- Savage Gladiator's Shield Wall
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42217, {	-- Savage Gladiator's Shiv
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42219, {	-- Savage Gladiator's Slasher
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42224, {	-- Savage Gladiator's Slicer
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42343, {	-- Savage Gladiator's Spellblade
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42388, {	-- Savage Gladiator's Staff
+							["timeline"] = { CREATED_3_0_2 },
+						}),
+						i(42448, {	-- Savage Gladiator's Touch of Defeat
+							["timeline"] = { CREATED_3_0_2 },
+						}),
 						-- #if BEFORE MOP
 						i(42444, {	-- Savage Gladiator's War Edge (Throw Wep)
 							["timeline"] = { REMOVED_5_0_4 },
 						}),
 						-- #endif
-						i(44415),	-- Savage Gladiator's War Staff
+						i(44415, {	-- Savage Gladiator's War Staff
+							["timeline"] = { CREATED_3_0_2 },
+						}),
 					}),
 					cl(DEATHKNIGHT, {
 						i(146580, {	-- Ensemble: Savage Gladiator's Dreadplate Armor

--- a/.contrib/Parser/DATAS/08 - PvP/03 Wrath of the Lich King PvP Seasons.lua
+++ b/.contrib/Parser/DATAS/08 - PvP/03 Wrath of the Lich King PvP Seasons.lua
@@ -101,100 +101,100 @@ root(ROOTS.PVP, applyclassicphase(WRATH_PHASE_ONE, run(MarkOfWHOOOWHATNow, bubbl
 						}),
 						-- Savage Gladiator weapons have never been implemented
 						i(42557, {	-- Savage Gladiator's Barrier
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42511, {	-- Savage Gladiator's Baton of Light
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42356, {	-- Savage Gladiator's Battle Staff
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42221, {	-- Savage Gladiator's Bonecracker
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42295, {	-- Savage Gladiator's Bonegrinder
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42212, {	-- Savage Gladiator's Chopper
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42206, {	-- Savage Gladiator's Cleaver
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42294, {	-- Savage Gladiator's Decapitator
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42382, {	-- Savage Gladiator's Energy Staff
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42220, {	-- Savage Gladiator's Fleshslicer
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(44416, {	-- Savage Gladiator's Focus Staff
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42344, {	-- Savage Gladiator's Gavel
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42297, {	-- Savage Gladiator's Greatsword
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42213, {	-- Savage Gladiator's Hacker
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42446, {	-- Savage Gladiator's Heavy Crossbow
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42445, {	-- Savage Gladiator's Longbow
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42215, {	-- Savage Gladiator's Mutilator
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42517, {	-- Savage Gladiator's Piercing Touch
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42296, {	-- Savage Gladiator's Pike
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42222, {	-- Savage Gladiator's Pummeler
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42223, {	-- Savage Gladiator's Quickblade
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42568, {	-- Savage Gladiator's Redoubt
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42447, {	-- Savage Gladiator's Rifle
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42218, {	-- Savage Gladiator's Ripper
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42216, {	-- Savage Gladiator's Shanker
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42556, {	-- Savage Gladiator's Shield Wall
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42217, {	-- Savage Gladiator's Shiv
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42219, {	-- Savage Gladiator's Slasher
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42224, {	-- Savage Gladiator's Slicer
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42343, {	-- Savage Gladiator's Spellblade
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42388, {	-- Savage Gladiator's Staff
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						i(42448, {	-- Savage Gladiator's Touch of Defeat
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 						-- #if BEFORE MOP
 						i(42444, {	-- Savage Gladiator's War Edge (Throw Wep)
@@ -202,7 +202,7 @@ root(ROOTS.PVP, applyclassicphase(WRATH_PHASE_ONE, run(MarkOfWHOOOWHATNow, bubbl
 						}),
 						-- #endif
 						i(44415, {	-- Savage Gladiator's War Staff
-							["timeline"] = { CREATED_3_0_2 },
+							["timeline"] = { CREATED_3_0_2, ADDED_7_2_0 },
 						}),
 					}),
 					cl(DEATHKNIGHT, {


### PR DESCRIPTION
tested on cata classic
on retail, items are not flagged correctly because they were added in 7.x into the weapon arsenal, I suppose some specific flag should be added