### PR TITLE
[Cata] fix missing items from wotlk dungeons

### DIFF
--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/03 - Wrath of the Lich King/Azjol-Nerub.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/03 - Wrath of the Lich King/Azjol-Nerub.lua
@@ -246,13 +246,13 @@ root(ROOTS.Instances, expansion(EXPANSION.WRATH, applyclassicphase(WRATH_PHASE_O
 							-- #endif
 						}),
 						i(37244, {	-- Fungi-Coated Boots
-							["timeline"] = { CREATED_3_0_2, ADDED_4_0_3 },
+							["timeline"] = { CREATED_3_0_2, ADDED_8_0_1 },
 							-- #if AFTER 8.0.1
 							["cr"] = 29128,	-- Anub'ar Prime Guard [BLIZZARD BROKE THE REST LOL GOODLUCK]
 							-- #endif
 						}),
 						i(37245, {	-- Tangled Web Bindings
-							["timeline"] = { CREATED_3_0_2, ADDED_4_0_3 },
+							["timeline"] = { CREATED_3_0_2, ADDED_8_0_1 },
 							-- #if AFTER 8.0.1
 							["cr"] = 29128,	-- Anub'ar Prime Guard [BLIZZARD BROKE THE REST LOL GOODLUCK]
 							-- #endif

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/03 - Wrath of the Lich King/Halls of Stone.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/03 - Wrath of the Lich King/Halls of Stone.lua
@@ -125,7 +125,9 @@ root(ROOTS.Instances, expansion(EXPANSION.WRATH, applyclassicphase(WRATH_PHASE_O
 				e(604, {	-- Krystallus
 					["creatureID"] = 27977,	-- Krystallus
 					["groups"] = {
-						i(37649),	-- Quarry Chisel
+						i(37649, {	-- Quarry Chisel
+							["timeline"] = { CREATED_3_0_2, ADDED_7_3_5 },
+						}),
 						i(35670),	-- Brann's Lost Mining Helmet
 						i(35672),	-- Hollow Geode Helm
 						-- #if AFTER 7.3.5


### PR DESCRIPTION
Quarry Chisel : not added in cata (surely 7.x)
Fungi-Coated Boots & Tangled Web Bindings : not added in cata (surely in 8.x)