### PR TITLE
[Cata] tag day of the dead mask as not collectible

### DIFF
--- a/.contrib/Parser/DATAS/21 - Holidays/Day of the Dead.lua
+++ b/.contrib/Parser/DATAS/21 - Holidays/Day of the Dead.lua
@@ -232,6 +232,9 @@ root(ROOTS.Holidays, applyevent(EVENTS.DAY_OF_THE_DEAD, n(DAY_OF_THE_DEAD_HEADER
 					}),
 					i(46860, {	-- Whimsical Skull Mask (Cosmetic)
 						["timeline"] = { ADDED_3_2_2 },
+						-- #if BEFORE LEGION
+						["collectible"] = false,
+						-- #endif
 					}),
 					i(79048, {	-- Whimsical Skull Mask
 						["timeline"] = { ADDED_5_0_4 },


### PR DESCRIPTION
let's consider 8.x for white items
this one is temporary "Requires Day of the Dead"