### PR TITLE
Fixed timeline in dungeons/raids added in a patch to fix wrong data in tooltips

### DIFF
--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/0.9 World Bosses.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/0.9 World Bosses.lua
@@ -14,7 +14,7 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, {
 		["isRaid"] = true,
 		["lvl"] = 60,
 		["groups"] = {
-			applyclassicphase(PHASE_TWO, bubbleDown({ ["timeline"] = { REMOVED_4_0_3 } }, n(6109, {	-- Azuregos
+			applyclassicphase(PHASE_TWO, bubbleDown({ ["timeline"] = { ADDED_1_3_0, REMOVED_4_0_3 } }, n(6109, {	-- Azuregos
 				["coord"] = { 53.3, 80.4, AZSHARA },
 				["isRaid"] = true,
 				-- #if ANYCLASSIC
@@ -35,7 +35,7 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, {
 					i(19131),	-- Snowblind Shoes
 				},
 			}))),
-			applyclassicphase(PHASE_FOUR, bubbleDown({ ["timeline"] = { REMOVED_4_0_3 } }, n(DRAGONS_OF_NIGHTMARE, {
+			applyclassicphase(PHASE_FOUR, bubbleDown({ ["timeline"] = { ADDED_1_8_0, REMOVED_4_0_3 } }, n(DRAGONS_OF_NIGHTMARE, {
 				["coords"] = {
 					{ 51.2, 10.9, FERALAS },
 					{ 63.3, 27.8, THE_HINTERLANDS },
@@ -143,7 +143,7 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, {
 					}),
 				},
 			}))),
-			applyclassicphase(PHASE_TWO, bubbleDown({ ["timeline"] = { REMOVED_2_0_1 } }, n(12397, {	-- Lord Kazzak / Highlord Kruul
+			applyclassicphase(PHASE_TWO, bubbleDown({ ["timeline"] = {  ADDED_1_3_0, REMOVED_2_0_1 } }, n(12397, {	-- Lord Kazzak / Highlord Kruul
 				["coord"] = { 36.6, 75.8, BLASTED_LANDS },
 				["crs"] = { 18338 },	-- Highlord Kruul
 				["modelScale"] = 6.0,

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/1.6 Blackwing Lair.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/1.6 Blackwing Lair.lua
@@ -40,7 +40,7 @@ local TOKENS = {
 	}
 };
 -- #endif
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_THREE, { ["timeline"] = { ADDED_1_6_0 } }, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_THREE, bubbleDown({ ["timeline"] = { ADDED_1_6_0 } }, {
 	inst(742, {	-- Blackwing Lair
 		["lore"] = "In the dark recesses of the mountain's peak, Nefarian, the eldest son of Deathwing, conducts some of his most awful experimentation, controlling mighty beings like puppets and combining the eggs of different dragonflights with horrific results. Should he prove successful, even darker pursuits rest on the horizon.\n\nAnd, yet, the Lord of Blackrock is not a mere scientist - he is a great dragon cornered in his lair. Can he truly be defeated by mortal hands?",
 		["provider"] = { "o", 179879 },	-- Orb of Command
@@ -1110,4 +1110,4 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_THREE
 			-- #endif
 		},
 	}),
-})));
+}))));

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/1.6 Blackwing Lair.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/1.6 Blackwing Lair.lua
@@ -40,7 +40,7 @@ local TOKENS = {
 	}
 };
 -- #endif
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_THREE, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_THREE, { ["timeline"] = { ADDED_1_6_0 } }, {
 	inst(742, {	-- Blackwing Lair
 		["lore"] = "In the dark recesses of the mountain's peak, Nefarian, the eldest son of Deathwing, conducts some of his most awful experimentation, controlling mighty beings like puppets and combining the eggs of different dragonflights with horrific results. Should he prove successful, even darker pursuits rest on the horizon.\n\nAnd, yet, the Lord of Blackrock is not a mere scientist - he is a great dragon cornered in his lair. Can he truly be defeated by mortal hands?",
 		["provider"] = { "o", 179879 },	-- Orb of Command

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/1.7 Zul'Gurub.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/1.7 Zul'Gurub.lua
@@ -7,7 +7,7 @@ local RAZZASHI_HATCHLING = i(48126, {	-- Razzashi Hatchling
 	["cr"] = 14821,	-- Razzashi Raptor
 });
 root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FOUR, {
-	inst(76, bubbleDownSelf({ ["timeline"] = { REMOVED_4_0_3 } }, {	-- Zul'Gurub
+	inst(76, bubbleDownSelf({ ["timeline"] = { ADDED_1_7_0, REMOVED_4_0_3 } }, {	-- Zul'Gurub
 		["lore"] = "Over a thousand years ago the powerful Gurubashi Empire was torn apart by a massive civil war. An influential group of troll priests, known as the Atal'ai, called forth the avatar of an ancient and terrible blood god named Hakkar the Soulflayer. Though the priests were defeated and ultimately exiled, the great troll empire collapsed upon itself. The exiled priests fled far to the north, into the Swamp of Sorrows, where they erected a great temple to Hakkar in order to prepare for his arrival into the physical world.",
 		-- #if BEFORE WRATH
 		["zone-text-areaID"] = 19,	-- Zul'Gurub

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.5 Ruins of Ahn'Qiraj.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.5 Ruins of Ahn'Qiraj.lua
@@ -6,6 +6,8 @@ CAPTAINS = createHeader({
 	icon = 236623,
 	text = {
 		en = "Captains",
+		es = "Capitanes",
+		mx = "Capitanes",
 		fr = "Capitaines",
 		ru = "Капитаны",
 		cn = "船长",
@@ -23,7 +25,7 @@ local KEYL_LOCATION = { 59.4, 14.0, AHNQIRAJ_THE_FALLEN_KINGDOM };
 local WARDEN_LOCATION = { 59.4, 14.0, AHNQIRAJ_THE_FALLEN_KINGDOM };
 local WINDCALLER_LOCATION = { 59.4, 14.0, AHNQIRAJ_THE_FALLEN_KINGDOM };
 -- #endif
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, { ["timeline"] = { ADDED_1_9_0 } }, {
 	inst(743, {	-- Ruins of Ahn'Qiraj
 		["lore"] = "Deep within the deserts of Silithus lies an ancient and powerful race of beings known as the Qiraji. One thousand years ago, the Night Elves and Bronze Dragonflight combined their considerable powers to seal the Qiraji behind the scarab wall with the help of the children of some of the aspects. This is remembered as the \"War of the Shifting Sands\".\n\nRecently it was discovered that some of the Qiraji were finding ways past the wall. Anachronos, the bronze dragon, helped the adventurers of Azeroth open the Scarab Wall to prevent more incursions. The mortal races have now banded together to confront the evil Qiraji in their own land. A champion has opened the gate and the Horde and Alliance have driven the armies of the Qiraji back into the ruins in retreat. It now falls to heroes to delve into the lair of the Qiraji and put an end to their masters once and for all",
 		-- #if BEFORE WRATH

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.5 Ruins of Ahn'Qiraj.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.5 Ruins of Ahn'Qiraj.lua
@@ -25,7 +25,7 @@ local KEYL_LOCATION = { 59.4, 14.0, AHNQIRAJ_THE_FALLEN_KINGDOM };
 local WARDEN_LOCATION = { 59.4, 14.0, AHNQIRAJ_THE_FALLEN_KINGDOM };
 local WINDCALLER_LOCATION = { 59.4, 14.0, AHNQIRAJ_THE_FALLEN_KINGDOM };
 -- #endif
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, { ["timeline"] = { ADDED_1_9_0 } }, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, bubbleDown({ ["timeline"] = { ADDED_1_9_0 } }, {
 	inst(743, {	-- Ruins of Ahn'Qiraj
 		["lore"] = "Deep within the deserts of Silithus lies an ancient and powerful race of beings known as the Qiraji. One thousand years ago, the Night Elves and Bronze Dragonflight combined their considerable powers to seal the Qiraji behind the scarab wall with the help of the children of some of the aspects. This is remembered as the \"War of the Shifting Sands\".\n\nRecently it was discovered that some of the Qiraji were finding ways past the wall. Anachronos, the bronze dragon, helped the adventurers of Azeroth open the Scarab Wall to prevent more incursions. The mortal races have now banded together to confront the evil Qiraji in their own land. A champion has opened the gate and the Horde and Alliance have driven the armies of the Qiraji back into the ruins in retreat. It now falls to heroes to delve into the lair of the Qiraji and put an end to their masters once and for all",
 		-- #if BEFORE WRATH
@@ -1156,4 +1156,4 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE,
 			-- #endif
 		},
 	}),
-})));
+}))));

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.6 Temple of Ahn'Qiraj.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.6 Temple of Ahn'Qiraj.lua
@@ -14,11 +14,13 @@ SILITHID_ROYALTY_SHARED_DROPS = createHeader({
 	icon = 133575,
 	text = {
 		en = "Silithid Royalty",
+		es = "Realeza Silitida",
+		mx = "Realeza Silitida",
 	},
 });
 -- #endif
 
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, { ["timeline"] = { ADDED_1_9_0 } }, {
 	inst(744, {	-- Temple of Ahn'Qiraj
 		["lore"] = "Dark whispers ride on the winds of Silithus desert. An old god stirs in his wretched lair and the entire world shall soon be the target of his wrath.\n\nAfter thousands of years of slumber, the old god, C'thun has awakened and is quickly regenerating his power. Once he has reached full potential nothing will be able to stop him. The dragons that so humbly sacrificed themselves so long ago to imprison C'thun are weakened or enslaved in the temple, so the charge of protecting the land falls to other heroes.\n\nHeroes must enter Temple of Ahn'Qiraj, challenge C'thun's most wicked servants, and slay a god. The road will not be easy and it is wrought with peril at every turn. Will the heroes turn back now or face C'thun in his mighty lair and put an end to him once and for all?",
 		-- #if BEFORE WRATH

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.6 Temple of Ahn'Qiraj.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.6 Temple of Ahn'Qiraj.lua
@@ -20,7 +20,7 @@ SILITHID_ROYALTY_SHARED_DROPS = createHeader({
 });
 -- #endif
 
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, { ["timeline"] = { ADDED_1_9_0 } }, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE, bubbleDown({ ["timeline"] = { ADDED_1_9_0 } }, {
 	inst(744, {	-- Temple of Ahn'Qiraj
 		["lore"] = "Dark whispers ride on the winds of Silithus desert. An old god stirs in his wretched lair and the entire world shall soon be the target of his wrath.\n\nAfter thousands of years of slumber, the old god, C'thun has awakened and is quickly regenerating his power. Once he has reached full potential nothing will be able to stop him. The dragons that so humbly sacrificed themselves so long ago to imprison C'thun are weakened or enslaved in the temple, so the charge of protecting the land falls to other heroes.\n\nHeroes must enter Temple of Ahn'Qiraj, challenge C'thun's most wicked servants, and slay a god. The road will not be easy and it is wrought with peril at every turn. Will the heroes turn back now or face C'thun in his mighty lair and put an end to him once and for all?",
 		-- #if BEFORE WRATH
@@ -3124,4 +3124,4 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE,
 			-- #endif
 		},
 	}),
-})));
+}))));

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/3.0 Naxxramas.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/3.0 Naxxramas.lua
@@ -7,6 +7,7 @@ THE_FOUR_HORSEMEN = createHeader({
 	text = {
 		en = "The Four Horsemen",
 		es = "Los Cuatro Jinetes",
+		mx = "Los Cuatro Jinetes",
 		de = "Die Vier Reiter",
 		fr = "Les quatre cavaliers",
 		it = "I Cavalieri dell'Apocalisse",

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/3.0 Naxxramas.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/3.0 Naxxramas.lua
@@ -22,7 +22,7 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC,
 applyclassicphase(PHASE_SIX,
 -- #endif
 {
-	inst(754, bubbleDownSelf({ ["timeline"] = { REMOVED_3_0_2 } }, {	-- Naxxramas
+	inst(754, bubbleDownSelf({ ["timeline"] = { ADDED_1_11_0, REMOVED_3_0_2 } }, {	-- Naxxramas
 		-- #if BEFORE MOP
 		["lore"] = "An ancient Nerubian ziggurat, Naxxramas was torn free from the ground by agents of the Lich King to serve as Kel'Thuzad's base of operations as he spreads the plague throughout Lordaeron.\n\nDue to Kel'Thuzad fighting a war against the Scarlet Crusade, the Argent Dawn, the Forsaken and the humans of the Alliance, as well as constant incursions of adventurers from every race and nation into the Scourge-controlled Plaguelands on a daily basis, his forces have been severely taxed to maintain the security of his necropolis. But now that the gates of Naxxramas are open, Kel'Thuzad's new forces are rapidly sweeping away all opposition to the Scourge.",
 		-- #endif

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/Dire Maul.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/Dire Maul.lua
@@ -124,7 +124,7 @@ local OnTooltipForSteamweedle = [[function(t, tooltipInfo)
 	end
 end]];
 -- #endif
-root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_ONE_DIREMAUL, {
+root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_ONE_DIREMAUL, bubbleDown({ ["timeline"] = { ADDED_1_2_0 } }, {
 	inst(230, {	-- Dire Maul
 		-- #if BEFORE MOP
 		["lore"] = "Dire Maul is a three-wing instance found in north-central Feralas. It was once a proud Highborne city called Eldre'Thalas, but now lies in ruins, overrun by ogres, satyrs, and undead. Only a tiny remnant of the original Highborne population remains in the form of a murderous sect called the Shen'dralar.",
@@ -2352,7 +2352,7 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_ONE_D
 			}),
 		},
 	}),
-})));
+}))));
 root(ROOTS.HiddenQuestTriggers, expansion(EXPANSION.WOD, bubbleDownSelf({ ["timeline"] = { ADDED_6_0_2 } }, {
 	inst(230, {
 		q(35890),	-- Dire Maul (Warpwood Quarter) Reward Quest - Normal completion

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/7 The Black Temple.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/7 The Black Temple.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_THREE, { ["timeline"] = { ADDED_2_1_0 } }, {
+root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_THREE, bubbleDownSelf({ ["timeline"] = { ADDED_2_1_0 } }, {
 	inst(751, {	-- The Black Temple
 		["lore"] = "When Illidan the Betrayer fled to Outland after the Third War, he ousted the Temple's ruler - the pit lord Magtheridon - and claimed his throne as the lord of the blasted world. Following his defeat at the hands of Arthas Menethil, Illidan returned to the Black Temple where he resides to this day. Neither his activities nor mental state are known at this time. While Malfurion has stated that Illidan has become mad and delusional, believing that he killed Arthas and accomplished the mission Kil'jaeden had sent him on.\n\nDespite the bitter retribution of his enemies, Illidan has begun to tighten his grip on Outland from within the profaned sanctum, where he awaits any and all who would challenge his rule.",
 		["coord"] = { 71.0, 46.5, SHADOWMOON_VALLEY },	-- Black Temple, Shadowmoon Valley
@@ -454,4 +454,4 @@ root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_THREE
 			-- #endif
 		},
 	}),
-})));
+}))));

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/7 The Black Temple.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/7 The Black Temple.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_THREE, {
+root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_THREE, { ["timeline"] = { ADDED_2_1_0 } }, {
 	inst(751, {	-- The Black Temple
 		["lore"] = "When Illidan the Betrayer fled to Outland after the Third War, he ousted the Temple's ruler - the pit lord Magtheridon - and claimed his throne as the lord of the blasted world. Following his defeat at the hands of Arthas Menethil, Illidan returned to the Black Temple where he resides to this day. Neither his activities nor mental state are known at this time. While Malfurion has stated that Illidan has become mad and delusional, believing that he killed Arthas and accomplished the mission Kil'jaeden had sent him on.\n\nDespite the bitter retribution of his enemies, Illidan has begun to tighten his grip on Outland from within the profaned sanctum, where he awaits any and all who would challenge his rule.",
 		["coord"] = { 71.0, 46.5, SHADOWMOON_VALLEY },	-- Black Temple, Shadowmoon Valley

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/8 Sunwell Plateau.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/8 Sunwell Plateau.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_FIVE, {
+root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_FIVE, { ["timeline"] = { ADDED_2_4_0 } }, {
 	inst(752, {	-- Sunwell Plateau
 		["lore"] = "Nearly seven thousand years ago, the Highborne were exiled from Kalimdor for refusing to give up arcane magic. Led by Dath'Remar Sunstrider, these elves founded their own kingdom of Quel'Thalas. For millennia the mystical pool of energy known as the Sunwell fueled the potent magic of the exiled high elves. Now, the remnants of this ancient fountain have become the Burning Legion's latest target as the demons prepare to summon their commander, Kil'jaeden, with the Sunwell's energy.",
 		-- #if BEFORE WRATH

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/8 Sunwell Plateau.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/02 - Burning Crusade/8 Sunwell Plateau.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_FIVE, { ["timeline"] = { ADDED_2_4_0 } }, {
+root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_FIVE, bubbleDownSelf({ ["timeline"] = { ADDED_2_4_0 } }, {
 	inst(752, {	-- Sunwell Plateau
 		["lore"] = "Nearly seven thousand years ago, the Highborne were exiled from Kalimdor for refusing to give up arcane magic. Led by Dath'Remar Sunstrider, these elves founded their own kingdom of Quel'Thalas. For millennia the mystical pool of energy known as the Sunwell fueled the potent magic of the exiled high elves. Now, the remnants of this ancient fountain have become the Burning Legion's latest target as the demons prepare to summon their commander, Kil'jaeden, with the Sunwell's energy.",
 		-- #if BEFORE WRATH
@@ -295,4 +295,4 @@ root(ROOTS.Instances, expansion(EXPANSION.TBC, applyclassicphase(TBC_PHASE_FIVE,
 			}),
 		},
 	}),
-})));
+}))));

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/2 Trial of Valor.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/2 Trial of Valor.lua
@@ -2,7 +2,7 @@
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
 
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_1_0 } }, {
 	inst(861, {	-- Trial of Valor
 		["isRaid"] = true,
 		["coord"] = { 70.4, 69.4, STORMHEIM },
@@ -414,7 +414,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			}),
 		},
 	}),
-}));
+})));
 root(ROOTS.HiddenQuestTriggers, expansion(EXPANSION.LEGION, bubbleDownSelf({ ["timeline"] = { ADDED_7_1_5 } }, {
 	inst(861, {
 		q(46661),	-- Odyn LFR

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/3 The Nighthold.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/3 The Nighthold.lua
@@ -2,7 +2,7 @@
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_1_0 } }, {
 	inst(786, {	-- The Nighthold
 		["isRaid"] = true,
 		["coords"] = {
@@ -1362,7 +1362,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			})
 		},
 	}),
-}));
+})));
 root(ROOTS.HiddenQuestTriggers, expansion(EXPANSION.LEGION, bubbleDownSelf({ ["timeline"] = { ADDED_7_1_0 } }, {
 	inst(786, {
 		q(45318),	-- Skorpyron

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/4 Tomb of Sargeras.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/4 Tomb of Sargeras.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_2_0 } }, {
 	inst(875, {	-- Tomb of Sargeras
 		["isRaid"] = true,
 		["coord"] = { 64.3, 21.0, BROKEN_SHORE },
@@ -1349,7 +1349,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			})
 		},
 	}),
-}));
+})));
 root(ROOTS.HiddenQuestTriggers, expansion(EXPANSION.LEGION, bubbleDownSelf({ ["timeline"] = { ADDED_7_2_0 } }, {
 	inst(875, {
 		q(48064),	-- Goroth Intro - first time cinematic prior to Goroth

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/5 Antorus.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/5 Antorus.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_3_0 } }, {
 	inst(946, {	-- Antorus, the Burning Throne
 		["isRaid"] = true,
 		["coord"] = { 54.9, 62.3, ANTORAN_WASTES },
@@ -1584,7 +1584,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			}),
 		},
 	}),
-}));
+})));
 
 root(ROOTS.HiddenQuestTriggers, {
 	expansion(EXPANSION.LEGION, bubbleDownSelf({ ["timeline"] = { ADDED_7_3_0 } }, {

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/6 Invasion Points.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/1 - Raids/6 Invasion Points.lua
@@ -2,7 +2,7 @@
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
 
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_3_0 } }, {
 	inst(959, {	-- Invasion Points
 		["isRaid"] = true,
 		-- ["sourceQuests"] = { },	-- TODO pretty sure a quest is required to unlock these
@@ -429,7 +429,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			}),
 		},
 	}),
-}));
+})));
 
 root(ROOTS.HiddenQuestTriggers, expansion(EXPANSION.LEGION, bubbleDownSelf({ ["timeline"] = { ADDED_7_3_0 } }, {
 	inst(959, {

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Cathedral of Eternal Night.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Cathedral of Eternal Night.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_2_0 } }, {
 	inst(900, {	-- Cathedral of Eternal Night
 		["coord"] = { 64.7, 16.6, BROKEN_SHORE },
 		["maps"] = { 845, 846, 847, 848, 849 },
@@ -182,4 +182,4 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			}),
 		},
 	}),
-}));
+})));

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Return to Karazhan.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Return to Karazhan.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_1_0 } }, {
 	inst(860, {	-- Return to Karazhan
 		["coord"] = { 46.7, 70.1, DEADWIND_PASS },
 		["maps"] = {
@@ -602,7 +602,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, {
 			}),
 		},
 	}),
-}));
+})));
 
 root(ROOTS.HiddenQuestTriggers, expansion(EXPANSION.LEGION, bubbleDownSelf({ ["timeline"] = { ADDED_7_1_0 } }, {
 	inst(860, {

--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Seat of the Triumvirate.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Seat of the Triumvirate.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------
 --   D U N G E O N S  &  R A I D S  M O D U L E    --
 -----------------------------------------------------
-root(ROOTS.Instances, { expansion(EXPANSION.LEGION, {
+root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { ADDED_7_3_0 } }, {
 	inst(945, {	-- Seat of the Triumvirate
 		["lvl"] = 110,
 		["mapID"] = 903,
@@ -271,4 +271,4 @@ root(ROOTS.Instances, { expansion(EXPANSION.LEGION, {
 			}),
 		},
 	}),
-})});
+})));


### PR DESCRIPTION
Classic:

Maraudon
World Bosses
Blackwing Lair
Zul'Gurub
Ruins of Ahn'Qiraj
Temple of Ahn'Qiraj
Naxxramas

TBC:

The Black temple
Sunwell plateau

Legion:

Invasion points
Trial of Valor
The Nighthold
Tomb of Sargeras
Antorus
Return of Karazhan
Seat of the triumvirate
Cathedral of Eternal Night