### PR TITLE
Fix the ID of Viceroy Nezhar in hero and mythic

### DIFF
--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Seat of the Triumvirate.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/07 - Legion/2 - Dungeons/Seat of the Triumvirate.lua
@@ -165,7 +165,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { 
 					i(151294),	-- Coalesced Void
 					i(151295),	-- Darkstorm Arrowhead
 				})),
-				cr(124309, e(1981, {	-- Viceroy Nezhar
+				cr(122056, e(1981, {	-- Viceroy Nezhar
 					i(151316),	-- Cinch of the Umbral Lasher
 					i(151333),	-- Crown of the Dark Envoy
 					i(151305),	-- Entropic Wristwraps
@@ -235,7 +235,7 @@ root(ROOTS.Instances, expansion(EXPANSION.LEGION, bubbleDown({ ["timeline"] = { 
 						i(151294),	-- Coalesced Void
 						i(151295),	-- Darkstorm Arrowhead
 					})),
-					cr(124309, e(1981, {	-- Viceroy Nezhar
+					cr(122056, e(1981, {	-- Viceroy Nezhar
 						i(151316),	-- Cinch of the Umbral Lasher
 						i(151333),	-- Crown of the Dark Envoy
 						i(151305),	-- Entropic Wristwraps


### PR DESCRIPTION
Just now the boss only have the correct id in the quest part of the file but in the loot part is using wrong id

![imagen](https://github.com/user-attachments/assets/956cc7b2-6c09-45af-9c16-2886ee231a56)
