### PR TITLE
2 ToT fixes

### DIFF
--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/05 - Mists of Pandaria/5 - Throne of Thunder.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/05 - Mists of Pandaria/5 - Throne of Thunder.lua
@@ -868,7 +868,7 @@ root(ROOTS.Instances, expansion(EXPANSION.MOP, bubbleDown({ ["timeline"] = { ADD
 						},
 					}),
 					n(COMMON_BOSS_DROPS, {
-						["description"] = "These can drop from any of the bosses other than Ra-den.",
+						["description"] = "These can drop from any of the bosses.",
 						["crs"] = {
 							69465,	-- Jin'rokh the Breaker
 							68476,	-- Horridon
@@ -880,6 +880,7 @@ root(ROOTS.Instances, expansion(EXPANSION.MOP, bubbleDown({ ["timeline"] = { ADD
 							70212,	-- Flaming Head
 							70247,	-- Venomous Head
 							70235,	-- Frozen Head
+							68065,	-- Megaera
 							69712,	-- Ji-Kun
 							68036,	-- Durumu the Forgotten
 							69017,	-- Primordius
@@ -1527,7 +1528,7 @@ root(ROOTS.Instances, expansion(EXPANSION.MOP, bubbleDown({ ["timeline"] = { ADD
 				["ignoreBonus"] = true,
 				["g"] = {
 					n(COMMON_BOSS_DROPS, {
-						["description"] = "These can drop from any of the bosses other than Ra-den.",
+						["description"] = "These can drop from any of the bosses.",
 						["crs"] = {
 							69465,	-- Jin'rokh the Breaker
 							68476,	-- Horridon


### PR DESCRIPTION
Fixes the minilist of LFR of ToT where megaera is missing in the common drops part

Removed redundant comment on LFR and Normal because ra den does not exist on those difficulties