### PR TITLE
[Parser] Concurrency & cleanup revision

### DIFF
--- a/.contrib/Parser/.config/retail/retail.config
+++ b/.contrib/Parser/.config/retail/retail.config
@@ -103,6 +103,12 @@
                     99999
                 ]
             },
+            "currencyID": {
+                "bounds": [
+                    0,
+                    3360
+                ]
+            },
             "questID": {
                 "bounds": [
                     1,

--- a/.contrib/Parser/.config/root.config
+++ b/.contrib/Parser/.config/root.config
@@ -1,4 +1,5 @@
 {
+    "UseExportNewlines" : false,
     "SINGULAR_PLURAL_FIELDS_LONG": {
         "sourceAchievement": "sourceAchievements",
         "sourceQuest": "sourceQuests",

--- a/.contrib/Parser/DATAS/00 - DB/Parser Setup Data/MERGE_OBJECT_FIELDS.lua
+++ b/.contrib/Parser/DATAS/00 - DB/Parser Setup Data/MERGE_OBJECT_FIELDS.lua
@@ -8,5 +8,5 @@ MERGE_OBJECT_FIELDS = {
 	speciesID = { "pb","crs" },
 	instanceID = { "isRaid" },
 	mapID = { "maps" },
-	questID = { "type","sourceQuests","altQuests","isBreadcrumb","c","races","_type","_area","_category","_text","name","description","nextQuests" },
+	questID = { "type","sourceQuests","altQuests","isBreadcrumb","c","r","races","lvl","OnTooltip","_type","_area","_category","_text","name","description","nextQuests","isDaily","isMonthly","isYearly","repeatable","g" },
 }

--- a/.contrib/Parser/DATAS/00 - DB/Parser Setup Data/MERGE_OBJECT_FIELDS.lua
+++ b/.contrib/Parser/DATAS/00 - DB/Parser Setup Data/MERGE_OBJECT_FIELDS.lua
@@ -8,5 +8,5 @@ MERGE_OBJECT_FIELDS = {
 	speciesID = { "pb","crs" },
 	instanceID = { "isRaid" },
 	mapID = { "maps" },
-	questID = { "type","sourceQuests","altQuests","isBreadcrumb" },
+	questID = { "type","sourceQuests","altQuests","isBreadcrumb","c","races","_type","_area","_category","_text","name","description","nextQuests" },
 }

--- a/.contrib/Source Code/Parser/Export/Export (Compressed Lua).cs
+++ b/.contrib/Source Code/Parser/Export/Export (Compressed Lua).cs
@@ -14,7 +14,7 @@ namespace ATT
     {
         /// <summary>
         /// Allows to define whether LUA tables exported will include newlines or not<para/>
-        /// Default: false
+        /// Default: Config.UseExportNewlines
         /// </summary>
         public static bool AddTableNewLines { get; set; } = false;
 
@@ -193,6 +193,9 @@ namespace ATT
                 }
                 builder.Append('(').Append(onInitBody).Append(")(");
             }
+
+            if (AddTableNewLines)
+                builder.Append(Environment.NewLine);
 
             // If this is a constructed object type, then we need to write a parenthesis afterward.
             var constructed = ExportShortcut(builder, data, fields, out ObjectData objectType);
@@ -381,8 +384,8 @@ namespace ATT
         public static Exporter ExportCompressedLua(object data)
         {
             var builder = new Exporter();
+            AddTableNewLines = Framework.Config["UseExportNewlines"];
             ExportCompressedLua(builder, data);
-            AddTableNewLines = false;
             return builder;
         }
 
@@ -398,7 +401,7 @@ namespace ATT
         {
             var builder = new Exporter();
             ExportCompressedLua(builder, data);
-            AddTableNewLines = false;
+            AddTableNewLines = Framework.Config["UseExportNewlines"];
             return builder;
         }
 
@@ -412,7 +415,7 @@ namespace ATT
         {
             var builder = new Exporter();
             ExportCompressedLua(builder, list);
-            AddTableNewLines = false;
+            AddTableNewLines = Framework.Config["UseExportNewlines"];
             return builder;
         }
 
@@ -438,7 +441,7 @@ namespace ATT
             builder.Insert(0, new StringBuilder()
                 .AppendLine("---@diagnostic disable: deprecated")
                 .AppendLine("local appName, _ = ...;"));
-            AddTableNewLines = false;
+            AddTableNewLines = Framework.Config["UseExportNewlines"];
             return builder;
         }
 
@@ -483,7 +486,7 @@ namespace ATT
             }
             ExportLocalVariablesForLua(builder);
             ExportCategoriesHeaderForLua(builder);
-            AddTableNewLines = false;
+            AddTableNewLines = Framework.Config["UseExportNewlines"];
             return builder;
         }
 

--- a/.contrib/Source Code/Parser/FieldTypes/Cost.cs
+++ b/.contrib/Source Code/Parser/FieldTypes/Cost.cs
@@ -106,22 +106,26 @@ namespace ATT.FieldTypes
 
             if (_costTypes == null) return;
 
-            //foreach (var costType in _costTypes)
-            //{
-            //    switch (costType.Key)
-            //    {
-            //        //case "i":
-            //        //    foreach (var costRecord in costType.Value)
-            //        //    {
-            //        //    }
-            //        //    break;
-            //        //case "c":
-            //        //    foreach (var costRecord in costType.Value)
-            //        //    {
-            //        //    }
-            //        //    break;
-            //    }
-            //}
+            foreach (var costType in _costTypes)
+            {
+                switch (costType.Key)
+                {
+                    case "i":
+                        foreach (var costRec in costType.Value)
+                        {
+                            decimal costID = costRec.Key;
+                            Validator.Validate("itemID", costID, _data);
+                        }
+                        break;
+                    case "c":
+                        foreach (var costRec in costType.Value)
+                        {
+                            decimal costID = costRec.Key;
+                            Validator.Validate("currencyID", costID, _data);
+                        }
+                        break;
+                }
+            }
         }
 
         public void Incorporate() { }
@@ -196,6 +200,12 @@ namespace ATT.FieldTypes
                             {
                                 _data["pvp"] = true;
                             }
+
+                            // Ensure the Currency has been Sourced since it will need to show as a Cost in-game
+                            if (!TryGetSOURCED("currencyID", costID, out var _))
+                            {
+                                LogWarn($"Non-Sourced 'cost-currency' {costID}", _data);
+                            }
                             break;
                         }
                         break;
@@ -207,7 +217,7 @@ namespace ATT.FieldTypes
                 _costTypes["i"].Remove(id);
             }
 
-            foreach(var costType in _costTypes)
+            foreach (var costType in _costTypes)
             {
                 if (costType.Value.Count == 0)
                 {
@@ -215,7 +225,7 @@ namespace ATT.FieldTypes
                 }
             }
 
-            foreach(var costType in cleanTypes)
+            foreach (var costType in cleanTypes)
             {
                 _costTypes.Remove(costType);
             }

--- a/.contrib/Source Code/Parser/FieldTypes/Cost.cs
+++ b/.contrib/Source Code/Parser/FieldTypes/Cost.cs
@@ -204,7 +204,8 @@ namespace ATT.FieldTypes
                             // Ensure the Currency has been Sourced since it will need to show as a Cost in-game
                             if (!TryGetSOURCED("currencyID", costID, out var _))
                             {
-                                LogWarn($"Non-Sourced 'cost-currency' {costID}", _data);
+                                // TODO: remove debug once all warnings are fixed
+                                LogDebugWarn($"Non-Sourced 'cost-currency' {costID}", _data);
                             }
                             break;
                         }

--- a/.contrib/Source Code/Parser/Framework/Framework.Items.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Items.cs
@@ -703,6 +703,13 @@ namespace ATT
                     //    break;
 
                     default:
+
+                        // __parent is never merged into DB containers
+                        if (field == "__parent")
+                        {
+                            break;
+                        }
+
                         // for undefined parser-only fields, just use the base Object merge implementation for the Item
                         if (field.StartsWith("_"))
                         {
@@ -812,7 +819,7 @@ namespace ATT
             /// Specify conditional merge to skip creating an ItemDB entry if it does not already exist
             /// </summary>
             /// <param name="data">The data to merge into the item database.</param>
-            public static void MergeFromObject(IDictionary<string, object> data, bool conditionalMerge = false)
+            public static void MergeFromObject(IDictionary<string, object> data)
             {
                 //if (DebugMode)
                 //{
@@ -835,7 +842,7 @@ namespace ATT
                 //}
                 // TODO: This is just Crieve trying to make it more clear where the source of this information is coming from.
                 // I'd like to (at some point) make all information from ItemDB always attribute and information from objects be limited to context.
-                Merge(data, conditionalMerge);
+                Merge(data, false);
             }
             #endregion
 

--- a/.contrib/Source Code/Parser/Framework/Framework.Items.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Items.cs
@@ -698,9 +698,9 @@ namespace ATT
                     //case "OnInit":
                     //case "OnClick":
                     //case "OnUpdate":
-                    //case "OnTooltip":
-                    //    item[field] = value;
-                    //    break;
+                    case "OnTooltip":
+                        item[field] = value;
+                        break;
 
                     default:
 

--- a/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
@@ -571,6 +571,15 @@ namespace ATT
                                 LogDebugWarn($"Merging different value into Object.{field}='{ToJSON(existingVal)}' from DB='{ToJSON(val)}'", data);
                                 Merge(data, field, val);
                             }
+
+                            // In some cases, the DB merge may include nested groups, so we need to apply inherited fields if this was the case
+                            if (field == "g" && data.TryGetValue("g", out List<object> groups))
+                            {
+                                foreach (var group in groups.AsTypedEnumerable<IDictionary<string, object>>())
+                                {
+                                    Validate_InheritedFields(group, data);
+                                }
+                            }
                         }
                     }
                 }

--- a/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
@@ -525,6 +525,10 @@ namespace ATT
                     // merge the allowed fields by the key into the merged object
                     foreach (string field in mergeObjectFieldPair.Value)
                     {
+                        // 'g' is never allowed to merge from an object, even is allowed in MERGE_OBJECT_FIELDS to merge into an object from the DB
+                        if (field == "g")
+                            continue;
+
                         if (!objectData.TryGetValue(field, out object val))
                             continue;
 

--- a/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
@@ -1074,14 +1074,28 @@ namespace ATT
 
                 // Build all categories
                 ConcurrentDictionary<string, Exporter> categoryBuilders = new ConcurrentDictionary<string, Exporter>();
-                AllContainerClones.AsParallel().ForAll((containerPair) =>
+                if (Debugger.IsAttached)
                 {
-                    if (containerPair.Value.Count > 0)
+                    foreach(var containerPair in AllContainerClones)
                     {
-                        // Build the category file.
-                        categoryBuilders[containerPair.Key] = ATT.Export.ExportCompressedLuaCategory(containerPair.Key, containerPair.Value);
+                        if (containerPair.Value.Count > 0)
+                        {
+                            // Build the category file.
+                            categoryBuilders[containerPair.Key] = ATT.Export.ExportCompressedLuaCategory(containerPair.Key, containerPair.Value);
+                        }
                     }
-                });
+                }
+                else
+                {
+                    AllContainerClones.AsParallel().ForAll((containerPair) =>
+                    {
+                        if (containerPair.Value.Count > 0)
+                        {
+                            // Build the category file.
+                            categoryBuilders[containerPair.Key] = ATT.Export.ExportCompressedLuaCategory(containerPair.Key, containerPair.Value);
+                        }
+                    });
+                }
 
                 // Simplify the structure of each Category builder
                 if (!PreProcessorTags.Contains("NOSIMPLIFY"))

--- a/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
@@ -2068,6 +2068,12 @@ end");
                                 return;
                             }
 
+                            // __parent is never merged into DB containers
+                            if (field == "__parent")
+                            {
+                                break;
+                            }
+
                             // Integer Data Type Fields
                             if (ATT.Export.ObjectData.ContainsObjectType(field))
                             {

--- a/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
@@ -483,7 +483,7 @@ namespace ATT
                         if (pair.Key == primaryKey)
                             continue;
 
-                        merged[pair.Key] = pair.Value;
+                        Merge(merged, pair.Key, pair.Value);
                     }
                 }
                 else

--- a/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Objects.cs
@@ -70,11 +70,6 @@ namespace ATT
             }
 
             /// <summary>
-            /// All of the Quests that are in the database. This is solely used to add information to breadcrumb quests.
-            /// </summary>
-            public static IDictionary<long, IDictionary<string, object>> AllQuests { get; } = new Dictionary<long, IDictionary<string, object>>();
-
-            /// <summary>
             /// All of the Recipes (Name,RecipeID) that are in the database, keyed by required skill
             /// </summary>
             public static IDictionary<long, Dictionary<long, string>> AllRecipes { get; } = new Dictionary<long, Dictionary<long, string>>();
@@ -2396,47 +2391,23 @@ end");
             /// <summary>
             /// Handles merging the individual Quest data with the global set of Quest data references for later processing
             /// </summary>
-            public static void MergeQuestData(IDictionary<string, object> data)
+            public static void ReferenceQuestIDs(IDictionary<string, object> data)
             {
-                if (!data.TryGetValue("questID", out long questID)) return;
-
-                QUESTS_WITH_REFERENCES[questID] = true;
+                if (data.TryGetValue("questID", out long questID))
+                {
+                    QUESTS_WITH_REFERENCES[questID] = true;
+                }
 
                 // Alliance-Only QuestID
                 if (data.TryGetValue("questIDA", out long questIDA))
                 {
                     QUESTS_WITH_REFERENCES[questIDA] = true;
                 }
+
                 // Horde-Only QuestID
                 if (data.TryGetValue("questIDH", out long questIDH))
                 {
                     QUESTS_WITH_REFERENCES[questIDH] = true;
-                }
-
-                // merge any quest information from the quest DB into the data
-                if (QUESTS.TryGetValue(questID, out IDictionary<string, object> dbQuest))
-                {
-                    PreMerge(data, dbQuest);
-                    Merge(data, dbQuest);
-                }
-
-                // add this quest data to the set of AllQuests in case it is referenced by a breadcrumb or another sourceQuest
-                if (!AllQuests.ContainsKey(questID))
-                {
-                    AllQuests.Add(questID, data);
-                }
-                else
-                {
-                    IDictionary<string, object> quest = AllQuests[questID];
-                    // Copy in any additional pertinent data due to the quest information being listed in another location as well
-                    if (data.TryGetValue("sourceQuests", out List<object> sourceQuests))
-                    {
-                        Merge(quest, "sourceQuests", sourceQuests);
-                    }
-                    if (data.TryGetValue("isBreadcrumb", out bool isBreadcrumb))
-                    {
-                        Merge(quest, "isBreadcrumb", isBreadcrumb);
-                    }
                 }
             }
 

--- a/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
@@ -941,6 +941,8 @@ namespace ATT
                 }
             }
 
+            CaptureForSOURCED(data);
+
             return true;
         }
 

--- a/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
@@ -4264,7 +4264,8 @@ namespace ATT
                     // if a timeline 'specifically' indicates a Thing is available, we will let that 'bubbleOut' the u value
                     // as long as the Thing itself isn't specifically also marked with 'u' directly
                     // as long as the Thing itself isn't an 'objective'
-                    if (data.ContainsAnyKey("u", "objectiveID"))
+                    // as long as the Thing itself isn't a 'criteria'
+                    if (data.ContainsAnyKey("u", "objectiveID", "criteriaID"))
                         break;
 
                     // or inherited a 'timeline' to itself

--- a/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
@@ -1533,10 +1533,10 @@ namespace ATT
             data["_remove"] = false;
         }
 
-        private static bool TryGetSOURCED(string field, object idObj, out HashSet<IDictionary<string, object>> sources)
+        internal static bool TryGetSOURCED(string field, object idObj, out HashSet<IDictionary<string, object>> sources)
         {
             if (SOURCED.TryGetValue(field, out Dictionary<long, HashSet<IDictionary<string, object>>> fieldSources)
-                && idObj is long id
+                && idObj.TryConvert(out long id)
                 && id > 0
                 && fieldSources.TryGetValue(id, out sources))
             {
@@ -1552,7 +1552,7 @@ namespace ATT
             foreach (KeyValuePair<string, object> field in data)
             {
                 if (SOURCED.TryGetValue(field.Key, out Dictionary<long, HashSet<IDictionary<string, object>>> fieldSources)
-                    && field.Value is long id && id > 0
+                    && field.Value.TryConvert(out long id) && id > 0
                     && fieldSources.TryGetValue(id, out HashSet<IDictionary<string, object>> objectSources))
                 {
                     yield return objectSources;
@@ -1563,7 +1563,7 @@ namespace ATT
         private static IEnumerable<HashSet<IDictionary<string, object>>> GetAllMatchingSOURCED(string field, object idObj)
         {
             if (SOURCED.TryGetValue(field, out Dictionary<long, HashSet<IDictionary<string, object>>> fieldSources)
-                && idObj is long id && id > 0
+                && idObj.TryConvert(out long id) && id > 0
                 && fieldSources.TryGetValue(id, out HashSet<IDictionary<string, object>> objectSources))
             {
                 yield return objectSources;

--- a/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.Processing.cs
@@ -3982,6 +3982,12 @@ namespace ATT
                     }
                 }
             }
+
+            // Don't include 'nextQuests' on regular quests, only on breadcrumbs
+            if (!data.TryGetValue("isBreadcrumb", out bool isBreadcrumb) || !isBreadcrumb)
+            {
+                data.Remove("nextQuests");
+            }
         }
 
         private static void Consolidate_awprwp(IDictionary<string, object> data)

--- a/.contrib/Source Code/Parser/Framework/Framework.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.cs
@@ -153,6 +153,7 @@ namespace ATT
         {
             { "achID", new Dictionary<long, HashSet<IDictionary<string, object>>>() },
             { "creatureID", new Dictionary<long, HashSet<IDictionary<string, object>>>() },
+            { "currencyID", new Dictionary<long, HashSet<IDictionary<string, object>>>() },
             { "explorationID", new Dictionary<long, HashSet<IDictionary<string, object>>>() },
             { "factionID", new Dictionary<long, HashSet<IDictionary<string, object>>>() },
             { "flightpathID", new Dictionary<long, HashSet<IDictionary<string, object>>>() },

--- a/.contrib/Source Code/Parser/Framework/Framework.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.cs
@@ -403,6 +403,14 @@ namespace ATT
             }
         }
 
+        public static void Valdiate_headerID(IDictionary<string, object> data)
+        {
+            if (data.TryGetValue("headerID", out long headerID) && headerID < 1)
+            {
+                CUSTOM_HEADERS_WITH_REFERENCES[headerID] = true;
+            }
+        }
+
         /// <summary>
         /// Mark the Custom Header as Required.
         /// This will force it to be included in the export if it exists as a constant.
@@ -578,6 +586,14 @@ namespace ATT
 
                 _stage = value;
                 Log(_timer.ElapsedMilliseconds.ToString("000000 ") + _stage.ToString() + "...");
+                if (Handlers.TryGetValue(_stage, out var handler))
+                {
+                    CurrentParseStageHandler = handler;
+                }
+                else
+                {
+                    CurrentParseStageHandler = null;
+                }
             }
         }
 

--- a/.contrib/Source Code/Parser/Framework/Framework.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.cs
@@ -1642,27 +1642,13 @@ namespace ATT
         }
 
         /// <summary>
-        /// Convert the Dictionary to JSON using Mini JSON.
-        /// </summary>
-        public static string ToJSON(IDictionary<string, object> data)
-        {
-            // typically we don't want to serialize the 'g' content of a given 'data' object
-            // bit clunky but minijson doesn't seem to have much functionality... hence 'mini'
-            return MiniJSON.Json.Serialize(data.AsEnumerable().Where(kvp => kvp.Key != "g").ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
-        }
-
-        /// <summary>
         /// Convert the object to JSON using Mini JSON.
         /// </summary>
         /// <param name="obj">The object.</param>
         /// <returns>The JSON string.</returns>
         public static string ToJSON(object obj)
         {
-            if (obj is IDictionary<string, object> dict)
-            {
-                return ToJSON(dict);
-            }
-            else if (obj is IEnumerable<object> objs)
+            if (obj is IEnumerable<object> objs)
             {
                 return "[" + string.Join(",", objs.Select(o => ToJSON(o))) + "]";
             }

--- a/.contrib/Source Code/Parser/Framework/Framework.cs
+++ b/.contrib/Source Code/Parser/Framework/Framework.cs
@@ -107,7 +107,7 @@ namespace ATT
         /// </summary>
         public static Dictionary<string, int[]> FIRST_EXPANSION_PATCH { get; set; }
 
-        public static Dictionary<long,long> MAPID_MERGE_REPLACEMENTS { get; set; }
+        public static Dictionary<long, long> MAPID_MERGE_REPLACEMENTS { get; set; }
 
         /// <summary>
         /// Represents the function to use when performing a processing pass against the data
@@ -211,7 +211,7 @@ namespace ATT
         /// <summary>
         /// All of thePhase Constants listed by their constant name and id value.
         /// </summary>
-        private static IDictionary<string, long> PHASE_CONSTANTS = new Dictionary<string, long>();
+        private static IDictionary<string, long> PHASE_CONSTANTS = new ConcurrentDictionary<string, long>();
 
         /// <summary>
         /// All of the Phase IDs that have been referenced somewhere in the database.
@@ -227,11 +227,6 @@ namespace ATT
         /// All of the Export Data Keys that have been referenced somewhere in the database.
         /// </summary>
         private static IDictionary<string, List<string>> EXPORTDATA_WITH_REFERENCES = new ConcurrentDictionary<string, List<string>>();
-
-        /// <summary>
-        /// All of the quests that have been parsed sorted by Quest ID.
-        /// </summary>
-        private static IDictionary<long, IDictionary<string, object>> QUESTS = new Dictionary<long, IDictionary<string, object>>();
 
         /// <summary>
         /// All of the achievements that have been parsed sorted by Achievement ID.
@@ -604,7 +599,7 @@ namespace ATT
         /// <summary>
         /// A Dictionary of key-ID types and how many times each value of key-type has been referenced in the final DB
         /// </summary>
-        public static Dictionary<string, Dictionary<decimal, int>> TypeUseCounts { get; } = new Dictionary<string, Dictionary<decimal, int>>();
+        public static ConcurrentDictionary<string, ConcurrentDictionary<decimal, int>> TypeUseCounts { get; } = new ConcurrentDictionary<string, ConcurrentDictionary<decimal, int>>();
 
         /// <summary>
         /// A Dictionary of key-ID types and how many times each value of key-type has been referenced in the final DB
@@ -827,7 +822,7 @@ namespace ATT
             {
                 foreach (string type in configUseCounts)
                 {
-                    TypeUseCounts[type] = new Dictionary<decimal, int>();
+                    TypeUseCounts[type] = new ConcurrentDictionary<decimal, int>();
                 }
             }
             string[] configDebugDBs = Config["DebugDB"];

--- a/.contrib/Source Code/Parser/Framework/Handler.cs
+++ b/.contrib/Source Code/Parser/Framework/Handler.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using DataCondition = System.Func<System.Collections.Generic.IDictionary<string, object>, bool>;
+using DataAction = System.Action<System.Collections.Generic.IDictionary<string, object>>;
+using Data = System.Collections.Generic.IDictionary<string, object>;
+
+namespace ATT
+{
+    public class Handler
+    {
+        /// <summary>
+        /// A static method which always returns true, useful for conditions which should always handle the data
+        /// </summary>
+        /// <returns>true</returns>
+        public static bool AlwaysHandle(Data _) => true;
+
+        public ParseStage Stage { get; set; }
+
+        public Dictionary<DataCondition, List<DataAction>> ConditionActions { get; set; }
+            = new Dictionary<DataCondition, List<DataAction>>();
+
+        public Dictionary<DataAction, List<Data>> ActionDatas { get; set; }
+            = new Dictionary<DataAction, List<Data>>();
+
+        public List<DataAction> ActionSequence { get; set; }
+            = new List<DataAction>();
+
+        public Handler(ParseStage stage)
+        {
+            Stage = stage;
+        }
+
+        public void AddConditionAction(DataCondition condition, DataAction action)
+        {
+            if (!ConditionActions.TryGetValue(condition, out var actions))
+            {
+                ConditionActions[condition] = actions = new List<DataAction>();
+            }
+
+            actions.Add(action);
+
+            if (!ActionDatas.ContainsKey(action))
+            {
+                ActionDatas[action] = new List<Data>();
+                ActionSequence.Add(action);
+            }
+        }
+
+        internal void AddData(Data data)
+        {
+            foreach (KeyValuePair<DataCondition, List<DataAction>> conditionActions in ConditionActions)
+            {
+                if (conditionActions.Key(data))
+                {
+                    foreach (var action in conditionActions.Value)
+                    {
+                        ActionDatas[action].Add(data);
+                    }
+                }
+            }
+        }
+
+        public void RunActions()
+        {
+            foreach (var act in ActionSequence)
+            {
+                Framework.Log($".. Running '{act.Method.Name}' on {ActionDatas[act].Count} groups");
+                if (Debugger.IsAttached)
+                {
+                    ActionDatas[act].ForEach(act);
+                }
+                else
+                {
+                    ActionDatas[act].AsParallel().ForAll(act);
+                }
+            }
+        }
+    }
+}

--- a/.contrib/Source Code/Parser/Framework/ParseStage.cs
+++ b/.contrib/Source Code/Parser/Framework/ParseStage.cs
@@ -16,8 +16,6 @@
         ConditionalData,
         Incorporation,
         Consolidation,
-        PostProcessing,
-        Cleanup,
         UnsortedGeneration,
         DataIntegrityAnalysis,
         ExportDebugData,

--- a/.contrib/Source Code/Parser/MiniJSON.cs
+++ b/.contrib/Source Code/Parser/MiniJSON.cs
@@ -77,6 +77,14 @@ namespace MiniJSON
     public static class Json
     {
         /// <summary>
+        /// A set of Dictionary keys that should be ignored when serializing to JSON
+        /// </summary>
+        public static HashSet<object> IGNORED_KEYS = new HashSet<object>()
+        {
+            "g", "__parent"
+        };
+
+        /// <summary>
         /// Parses the string json into a value
         /// </summary>
         /// <param name="json">A JSON string.</param>
@@ -518,7 +526,14 @@ namespace MiniJSON
                     SerializeString(e.ToString());
                     builder.Append(':');
 
-                    SerializeValue(obj[e]);
+                    if (IGNORED_KEYS.Contains(e))
+                    {
+                        SerializeString("<ignored>");
+                    }
+                    else
+                    {
+                        SerializeValue(obj[e]);
+                    }
 
                     first = false;
                 }

--- a/.contrib/Source Code/Parser/Parser.csproj
+++ b/.contrib/Source Code/Parser/Parser.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Framework\Framework.Items.cs" />
     <Compile Include="Framework\Framework.cs" />
     <Compile Include="Framework\Framework.Processing.cs" />
+    <Compile Include="Framework\Handler.cs" />
     <Compile Include="Framework\HierarchicalFieldAdjustments.cs" />
     <Compile Include="Framework\Structs.cs" />
     <Compile Include="Harvesters\ObjectHarvester.cs" />

--- a/.contrib/Source Code/Parser/Program.cs
+++ b/.contrib/Source Code/Parser/Program.cs
@@ -616,14 +616,14 @@ namespace ATT
                     }
 
                     if (output.Length > 0)
-                        Framework.Log($"{idSet.Key}: " + output.ToString());
+                        Framework.Log($"{idSet.Key} ({idSet.Value.Count}): " + output.ToString());
                 }
 
                 // Notify of duplicate object listings
                 foreach (string key in Framework.TypeUseCounts.Keys)
                 {
                     StringBuilder dupeIDs = new StringBuilder();
-                    Dictionary<decimal, int> idCounts = Framework.TypeUseCounts[key];
+                    var idCounts = Framework.TypeUseCounts[key];
                     int count = 0;
                     foreach (var id in idCounts
                         .Where(kvp => kvp.Value > 1)


### PR DESCRIPTION
Added a new implementation of a 'Handler' type which can be given condition-based Actions to perform against ATT data objects following specific Stages. It's probably a little overkill for the typical processing required within a given Action, hence I've tried to just combine various Actions into one final Action to reduce parallel processing overhead.

Also revised some merge handling and cross-referenced nearly all categories data to verify accurate outcomes.

I tried to push individual commits of the code changes to denote the actual change in a clear way for individual review if desired.