### PR TITLE
Dsypher2 Performance Optimization

### DIFF
--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -1555,8 +1555,7 @@ local function PrePopulateAchievementSymlinks()
 		local Run = app.FillRunner.Run
 		local group
 		for achID,groups in pairs(achCache) do
-			for i=1,#groups do
-				group = groups[i]
+			for _,group in app.IterateCachedFieldResults(groups) do
 				if group.__type == "Achievement" and not GetRelativeValue(group, "sourceIgnored") then
 					-- app.PrintDebug("FillAchSym",group.hash)
 					Run(FillSym, group)

--- a/AllTheThings.toc
+++ b/AllTheThings.toc
@@ -4,6 +4,8 @@
 ## Author: Crieve
 ## Version: @project-version@
 ## Interface: 11508, 11509, 20505, 20506, 38001, 40402, 50504, 120007, 120100
+## X-ATT-Midnight-API-Audit: 120007
+## X-ATT-Memory-Optimization: compact-index-v4-adaptive-gc-profiler
 ## X-Wago-ID: yQKyY5K7
 ## X-Curse-Project-ID: 267285
 ## Category-enUS: Collections
@@ -55,6 +57,7 @@ lib\Callback.lua
 src\base.lua
 src\Commands.lua
 src\Events.lua
+src\Modules\Performance.lua
 src\DataHandling.lua
 
 # Not really a lib concept...
@@ -89,6 +92,7 @@ src\Modules\Tooltip.lua
 src\Modules\Upgrade.lua
 src\Modules\Vignette.lua
 src\Modules\Contributor.lua
+src\Modules\Memory.lua
 #src\__test.lua
 
 # Load Database Files

--- a/src/Classes/Achievement Data.lua
+++ b/src/Classes/Achievement Data.lua
@@ -75,7 +75,7 @@ end
 local function GetRelatedThingsForExaltedReputations(t, objects)
 	for factionID,g in pairs(GetFieldContainer("factionID")) do
 		if not IgnoredReputationsForAchievements[factionID] then
-			for j,o in ipairs(g) do
+			for j,o in app.IterateCachedFieldResults(g) do
 				if o.key == "factionID" then
 					tinsert(objects, o);
 					break;
@@ -90,7 +90,7 @@ local function GetRelatedThingsForOwnItem(t, objects)
 end
 local function GetRelatedThingsForMounts(t, objects)
 	for spellID,spells in pairs(GetFieldContainer("mountID")) do
-		for i,spell in ipairs(spells) do
+		for i,spell in app.IterateCachedFieldResults(spells) do
 			tinsert(objects, spell);
 			break;
 		end
@@ -98,7 +98,7 @@ local function GetRelatedThingsForMounts(t, objects)
 end
 local function GetRelatedThingsForPets(t, objects)
 	for i,pets in pairs(GetFieldContainer("speciesID")) do
-		tinsert(objects, pets[1]);
+		tinsert(objects, app.GetFirstCachedFieldResult(pets));
 	end
 end
 local function GetRelatedThingsForQuest(t, objects)
@@ -144,7 +144,7 @@ local AchievementCriteriaCommands = {
 		local count = 0;
 		for factionID,g in pairs(GetFieldContainer("factionID")) do
 			if not IgnoredReputationsForAchievements[factionID] then
-				for j,o in ipairs(g) do
+				for j,o in app.IterateCachedFieldResults(g) do
 					if o.key == "factionID" and o.standing == 8 then
 						count = count + 1;
 						break;
@@ -163,7 +163,7 @@ local AchievementCriteriaCommands = {
 	CriteriaTypeForMounts = function()
 		local count = 0;
 		for i,g in pairs(GetFieldContainer("mountID")) do
-			for j,o in ipairs(g) do
+			for j,o in app.IterateCachedFieldResults(g) do
 				if o.collected then count = count + 1; end
 				break;
 			end
@@ -174,7 +174,7 @@ local AchievementCriteriaCommands = {
 	CriteriaTypeForPets = function()
 		local count = 0;
 		for i,g in pairs(GetFieldContainer("speciesID")) do
-			for j,o in ipairs(g) do
+			for j,o in app.IterateCachedFieldResults(g) do
 				if o.collected then count = count + 1; end
 				break;
 			end

--- a/src/Classes/Achievement.Classic.lua
+++ b/src/Classes/Achievement.Classic.lua
@@ -444,7 +444,7 @@ if GetCategoryInfo and (GetCategoryInfo(92) ~= "" and GetCategoryInfo(92) ~= nil
 					local collected = select(13, GetAchievementInfo(achievementID));
 					if collected ~= charAchievements[achievementID] then
 						local reference;
-						for i,o in ipairs(container) do
+						for i,o in app.IterateCachedFieldResults(container) do
 							if validAchievementKeys[o.key] then
 								reference = o;
 								break;

--- a/src/Classes/BattlePet.lua
+++ b/src/Classes/BattlePet.lua
@@ -20,19 +20,6 @@ local CLASSNAME = "BattlePet"
 local C_PetJournal_GetNumCollectedInfo,C_PetJournal_GetPetInfoByPetID,C_PetJournal_GetPetInfoBySpeciesID,C_PetJournal_GetPetInfoByIndex,C_PetJournal_GetNumPets,C_PetJournal_GetPetStats
 	= C_PetJournal.GetNumCollectedInfo,C_PetJournal.GetPetInfoByPetID,C_PetJournal.GetPetInfoBySpeciesID,C_PetJournal.GetPetInfoByIndex,C_PetJournal.GetNumPets,C_PetJournal.GetPetStats
 
--- Due to bad Blizzard data being returned from C_PetJournal.GetNumPets
--- we can only use the method of scanning the players collected pets if this API returns the proper number of total
--- pets existing within the game
-app.PrintDebug("BattlePet.Load:C_PetJournal_GetNumPets",C_PetJournal_GetNumPets())
-local TOTAL_PETS_FOR_SCAN
-if app.IsClassic then
-	-- TODO: adjust/revise if viable
-	TOTAL_PETS_FOR_SCAN = 100
-else
-	-- updated 11.1
-	TOTAL_PETS_FOR_SCAN = 2412
-end
-
 local cache = app.CreateCache(KEY);
 local function CacheInfo(t, field)
 	local _t, id = cache.GetCached(t);
@@ -101,16 +88,9 @@ app.CreateSpecies = app.CreateClass(CLASSNAME, KEY, {
 		return app.TypicalAccountCollected(CACHE, t[KEY])
 	end,
 	saved = function(t)
-		local saved = CollectedSpeciesHelper[t[KEY]] > 0
-		-- weird bug where ATT fails to scan battle pets,
-		-- can manually make it collected when checking the saved state (i.e. displayed in a row)
-		-- character collected
-		if saved then
-			if not t.collected then
-				app.SetThingCollected(KEY, t[KEY], not PerCharacterSpecies[t[KEY]], true)
-			end
-			return 1
-		end
+		-- Collection getters must be read-only. Reporting collection changes while a
+		-- row is rendered causes already-owned pets to be announced repeatedly.
+		return CollectedSpeciesHelper[t[KEY]] > 0 and 1 or nil
 	end,
 	text = function(t)
 		return t.link or cache.GetCachedField(t, "text", CacheInfo);
@@ -150,68 +130,37 @@ app.CreateSpecies = app.CreateClass(CLASSNAME, KEY, {
 function(t) return t.itemID end);
 
 local function RefreshBattlePets()
-	local totalPets, ownedPets = C_PetJournal_GetNumPets()
-	app.PrintDebug("RCBP",totalPets,ownedPets)
+	-- C_PetJournal.GetPetInfoByIndex is not a complete or stable authority for
+	-- collection ownership. Scan every species ATT knows about with the
+	-- species-specific API before replacing the saved caches.
 	wipe(CollectedSpeciesHelper)
 	local acct, char, none = {}, {}, {}
-	local count = 0
-	local num
-	-- ownedPets may reflect accurately but the C_PetJournal_GetPetInfoByIndex data will be missing entirely regardless
-	ownedPets = (totalPets or 0) >= TOTAL_PETS_FOR_SCAN and ownedPets or 0
-
-	if ownedPets > 0 then
-		-- ideally this is the case: we can scan user's actually-collected pets, track the petID's,
-		-- and everything is great
-		app.PrintDebug("RCBP:Scan")
-		local petID, speciesID
-		for i=1,ownedPets do
-			petID, speciesID = C_PetJournal_GetPetInfoByIndex(i)
-			-- app.PrintDebug("RCBP",i,petID,speciesID,speciesID and CollectedSpeciesHelper[speciesID])
-			-- apparently some users can have a nil speciesID here...
-			if speciesID then
-				num = CollectedSpeciesHelper[speciesID]
-				if num > 0 then
-					if petID then
-						PetIDSpeciesIDHelper[petID] = speciesID
-					end
-					if PerCharacterSpecies[speciesID] then
-						char[speciesID] = true
-					end
-					acct[speciesID] = true
-					count = count + 1
-				end
+	for speciesID in pairs(app.GetRawFieldContainer(KEY)) do
+		if CollectedSpeciesHelper[speciesID] > 0 then
+			acct[speciesID] = true
+			if PerCharacterSpecies[speciesID] then
+				char[speciesID] = true
 			end
-		end
-		-- when the actual set of learned pets has ACTUALLY been scanned and determined
-		-- we can wipe the BattlePet caches to ensure data is accurate
-		if count > 0 then
-			app.WipeCached(CACHE)
-			app.WipeCached(CACHE, true)
-		end
-	else
-		app.PrintDebug("RCBP:Cache")
-		-- otherwise we will have to use the ATT speciesID cache to scan collected, and this will mean that
-		-- caged pets will fail to be detected as removed immediately and require a refresh to detect
-		for speciesID,_ in pairs(app.GetRawFieldContainer("speciesID")) do
-			-- app.PrintDebug("RCBP",speciesID,CollectedSpeciesHelper[speciesID])
-			num = CollectedSpeciesHelper[speciesID]
-			if num > 0 then
-				if PerCharacterSpecies[speciesID] then
-					char[speciesID] = true
-				end
-				acct[speciesID] = true
-			else
-				none[speciesID] = true
-			end
+		else
+			none[speciesID] = true
 		end
 	end
-	-- Remove unknown
+
+	-- Keep the instance GUID lookup used by pet-added/deleted events. This index
+	-- is safe as supplemental metadata, but never as the source of ownership.
+	local _, ownedPets = C_PetJournal_GetNumPets()
+	for index = 1, ownedPets or 0 do
+		local petID, speciesID = C_PetJournal_GetPetInfoByIndex(index)
+		if petID and speciesID then
+			PetIDSpeciesIDHelper[petID] = speciesID
+		end
+	end
+
+	-- Replace stale values only after the authoritative species scan completes.
 	app.SetBatchCached(CACHE, none)
 	app.SetBatchAccountCached(CACHE, none)
-	-- Cache all ids which are known
 	app.SetBatchCached(CACHE, char, 1)
 	app.SetBatchAccountCached(CACHE, acct, 1)
-	-- app.PrintDebug("RCBP-Done")
 end
 app.AddEventHandler("OnRefreshCollections", RefreshBattlePets)
 app.AddEventHandler("OnSavedVariablesAvailable", function(currentCharacter, accountWideData)
@@ -220,8 +169,10 @@ app.AddEventHandler("OnSavedVariablesAvailable", function(currentCharacter, acco
 end)
 -- at some point speciesID began to be included in the Event payload, huzzah!
 app.AddEventRegistration("NEW_PET_ADDED", function(petID, speciesID)
-	local speciesID = speciesID or PetIDSpeciesIDHelper[petID]
-	PetIDSpeciesIDHelper[petID] = speciesID
+	local speciesID = speciesID or (petID and PetIDSpeciesIDHelper[petID])
+	if petID and speciesID then
+		PetIDSpeciesIDHelper[petID] = speciesID
+	end
 	-- app.PrintDebug("NEW_PET_ADDED", petID, speciesID)
 
 	if speciesID then
@@ -234,7 +185,7 @@ app.AddEventRegistration("NEW_PET_ADDED", function(petID, speciesID)
 end)
 -- at some point speciesID began to be included in the Event payload, huzzah!
 app.AddEventRegistration("PET_JOURNAL_PET_DELETED", function(petID, speciesID)
-	local speciesID = speciesID or PetIDSpeciesIDHelper[petID];
+	local speciesID = speciesID or (petID and PetIDSpeciesIDHelper[petID]);
 	-- app.PrintDebug("PET_JOURNAL_PET_DELETED",petID,speciesID);
 
 	if speciesID then

--- a/src/Classes/Classic/Mounts & Battle Pets.lua
+++ b/src/Classes/Classic/Mounts & Battle Pets.lua
@@ -74,7 +74,7 @@ app.AddEventHandler("OnRefreshCollections", function()
 		if IsSpellKnown(id) then
 			char[id] = true;
 		else
-			for i,o in ipairs(g) do
+			for i,o in app.IterateCachedFieldResults(g) do
 				if (o.questID and app.IsQuestFlaggedCompleted(o.questID)) or (o.itemID and GetItemCount(o.itemID, true) > 0) then
 					state = true;
 					break;
@@ -135,7 +135,7 @@ end);
 app.AddEventHandler("OnRefreshCollections", function()
 	local char, none, state = {}, {}, nil
 	for id,g in pairs(app.GetFieldContainer(KEY)) do
-		for i,o in ipairs(g) do
+		for i,o in app.IterateCachedFieldResults(g) do
 			if o.itemID and GetItemCount(o.itemID, true) > 0 then
 				state = true;
 				break;

--- a/src/Classes/FlightPath.lua
+++ b/src/Classes/FlightPath.lua
@@ -56,7 +56,7 @@ if app.IsGit then
 app.ChatCommands.Add("check-fps", function()
 	local missingByMapID, any = {}, false;
 	for flightpathID,flightPaths in pairs(app.GetFieldContainer("flightpathID")) do
-		for i,o in ipairs(flightPaths) do
+		for i,o in app.IterateCachedFieldResults(flightPaths) do
 			if not (o.crs or o.npcID or o.objectID or o.providers) and (not o.u or o.u >= 11) then
 				local mapID = app.GetRelativeValue(o, "mapID");
 				if mapID then

--- a/src/Classes/Gear Sets.lua
+++ b/src/Classes/Gear Sets.lua
@@ -15,7 +15,6 @@ local GetItemIcon = app.WOWAPI.GetItemIcon;
 -- Global locals
 local ipairs, select, tinsert, tonumber, type, GetAchievementInfo, GetAchievementLink,
 		C_TransmogCollection_GetSourceInfo, C_TransmogSets_GetSetInfo, C_TransmogSets_GetAllSourceIDs
-	---@diagnostic disable-next-line: deprecated
 	= ipairs, select, tinsert, tonumber, type, GetAchievementInfo, GetAchievementLink,
 		C_TransmogCollection.GetSourceInfo, C_TransmogSets.GetSetInfo, C_TransmogSets.GetAllSourceIDs;
 

--- a/src/Classes/Item.Retail.lua
+++ b/src/Classes/Item.Retail.lua
@@ -16,6 +16,7 @@ local ItemEventListener = ItemEventListener
 local GetItemInfo = app.WOWAPI.GetItemInfo;
 local GetItemIcon = app.WOWAPI.GetItemIcon;
 local GetItemCount = app.WOWAPI.GetItemCount;
+local GetItemSpell = app.WOWAPI.GetItemSpell;
 local IsBoAOverride = C_Item.IsItemBindToAccountUntilEquip or app.ReturnFalse;
 
 -- CRIEVE NOTE: Add this to Classic's LocalizationDB and then remove this.

--- a/src/Classes/Maps.lua
+++ b/src/Classes/Maps.lua
@@ -872,7 +872,7 @@ local function HarvestExploration()
 				end
 
 				-- If any were found, update the content of the exploration headers.
-				for i,object in ipairs(objects) do
+				for i,object in app.IterateCachedFieldResults(objects) do
 					if object.key == "mapID" and (object.mapID == mapID or (object.maps and contains(object.maps, mapID))) then
 						-- Cache or Create the Exploration Header
 						local explorationHeader = nil;
@@ -925,7 +925,7 @@ local function HarvestExploration()
 								if #searchResults < 1 or ReportedAreas[areaID] then
 									PrintDiscordInformationForExploration(o);
 								end
-								tinsert(searchResults, o);
+								app.AddCachedFieldResult("explorationID", areaID, o);
 							end
 						end
 					end

--- a/src/Classes/Miscellaneous.lua
+++ b/src/Classes/Miscellaneous.lua
@@ -112,7 +112,7 @@ local DynamicCategory_Simple = function(self)
 			local dynamicValueCache, thingKeys = dynamicCache[dynamicValue], app.ThingKeys;
 			if dynamicValueCache then
 				-- app.PrintDebug("DC:S",self.dynamic,self.dynamic_value,self.dynamic_withsubgroups)
-				for _,source in pairs(dynamicValueCache) do
+				for _,source in app.IterateCachedFieldResults(dynamicValueCache) do
 					-- only pull in actual 'Things' to the simple dynamic group
 					if thingKeys[source.key] and (not searchcriteria or searchcriteria(source)) then
 						-- find the top-level parent of the Thing
@@ -135,7 +135,7 @@ local DynamicCategory_Simple = function(self)
 		else
 			local thingKeys = app.ThingKeys
 			for id,sources in pairs(dynamicCache) do
-				for _,source in pairs(sources) do
+				for _,source in app.IterateCachedFieldResults(sources) do
 					-- only pull in actual 'Things' to the simple dynamic group
 					if thingKeys[source.key] and (not searchcriteria or searchcriteria(source)) then
 						-- find the top-level parent of the Thing

--- a/src/Classes/Spell.lua
+++ b/src/Classes/Spell.lua
@@ -13,15 +13,53 @@ local IsQuestFlaggedCompleted, SearchForField
 
 -- WoW API Cache
 local GetSpellLink = app.WOWAPI.GetSpellLink;
-
--- TODO: some of these deprecated in 11.2, move to WOWAPI
----@diagnostic disable-next-line: deprecated
-local GetSpellTabInfo = GetSpellTabInfo
-
--- WoW API
-local GetNumSpellTabs = app.WOWAPI.GetNumSpellTabs;
 local IsSpellKnown = app.WOWAPI.IsSpellKnown;
-local IsSpellKnownOrOverridesKnown = app.WOWAPI.IsSpellKnownOrOverridesKnown;
+local IsSpellInSpellBook = app.WOWAPI.IsSpellInSpellBook;
+
+-- Iterate the player spellbook through the current C_SpellBook API on Retail.
+-- Legacy clients keep their old implementation isolated from the Midnight path.
+local IteratePlayerSpellBook
+if app.IsRetail then
+	local C_SpellBook_GetNumSpellBookSkillLines = C_SpellBook.GetNumSpellBookSkillLines
+	local C_SpellBook_GetSpellBookSkillLineInfo = C_SpellBook.GetSpellBookSkillLineInfo
+	local C_SpellBook_GetSpellBookItemInfo = C_SpellBook.GetSpellBookItemInfo
+	local PLAYER_SPELL_BANK = Enum.SpellBookSpellBank.Player
+	local SPELL_ITEM_TYPE = Enum.SpellBookItemType.Spell
+	IteratePlayerSpellBook = function(callback)
+		for skillLineIndex = 1, C_SpellBook_GetNumSpellBookSkillLines() do
+			local skillLineInfo = C_SpellBook_GetSpellBookSkillLineInfo(skillLineIndex)
+			if skillLineInfo then
+				local firstIndex = skillLineInfo.itemIndexOffset + 1
+				local lastIndex = skillLineInfo.itemIndexOffset + skillLineInfo.numSpellBookItems
+				for spellBookItemIndex = firstIndex, lastIndex do
+					local itemInfo = C_SpellBook_GetSpellBookItemInfo(spellBookItemIndex, PLAYER_SPELL_BANK)
+					if itemInfo and itemInfo.itemType == SPELL_ITEM_TYPE and itemInfo.spellID and itemInfo.name then
+						callback(itemInfo.name, itemInfo.spellID)
+					end
+				end
+			end
+		end
+	end
+else
+	---@diagnostic disable: deprecated
+	local GetSpellTabInfo = GetSpellTabInfo
+	local GetNumSpellTabs = GetNumSpellTabs
+	local GetSpellInfo = GetSpellInfo
+	local GetSpellRank = GetSpellRank
+	---@diagnostic enable: deprecated
+	IteratePlayerSpellBook = function(callback)
+		if not GetSpellTabInfo or not GetNumSpellTabs or not GetSpellInfo then return end
+		for spellTabIndex = 1, GetNumSpellTabs() do
+			local _, _, offset, numSlots = GetSpellTabInfo(spellTabIndex)
+			for spellIndex = offset + 1, offset + numSlots do
+				local spellName, _, _, _, _, _, spellID = GetSpellInfo(spellIndex, BOOKTYPE_SPELL)
+				if spellName and spellID then
+					callback(spellName, spellID, GetSpellRank and GetSpellRank(spellID))
+				end
+			end
+		end
+	end
+end
 
 local SpellQuestLinks = {
 	-- double check added Mount spells in Mount.lua [PerCharacterMountSpells/AccountWideMountSpells]
@@ -45,29 +83,32 @@ local SpellQuestOverrides = setmetatable({}, { __index = function(t,key)
 	t[key] = saved
 	return saved
 end})
--- Consolidates some spell checking
+-- Consolidates spell checking without using the deprecated global spell APIs on Retail.
 ---@param spellID number
 ---@return boolean isKnown
 local IsSpellKnownHelper
--- In 11.2 some spell checking was consolidated
-if app.GameBuildVersion >= 110200 then
+if app.IsRetail then
+	local PLAYER_SPELL_BANK = Enum.SpellBookSpellBank.Player
+	local PET_SPELL_BANK = Enum.SpellBookSpellBank.Pet
 	IsSpellKnownHelper = function(spellID)
-		if IsSpellKnown(spellID)
-			or IsSpellKnown(spellID, 1)
-			or IsSpellKnownOrOverridesKnown(spellID, 0, true)
-			or IsSpellKnownOrOverridesKnown(spellID, 1, true)
+		if IsSpellKnown(spellID, PLAYER_SPELL_BANK)
+			or IsSpellKnown(spellID, PET_SPELL_BANK)
+			or IsSpellInSpellBook(spellID, PLAYER_SPELL_BANK, true)
+			or IsSpellInSpellBook(spellID, PET_SPELL_BANK, true)
 			or SpellQuestOverrides[spellID] then
 			return true
 		end
 	end
 else
-	local IsPlayerSpell = IsPlayerSpell;
+	---@diagnostic disable: deprecated
+	local IsPlayerSpell = IsPlayerSpell
+	---@diagnostic enable: deprecated
 	IsSpellKnownHelper = function(spellID)
-		if IsPlayerSpell(spellID)
+		if (IsPlayerSpell and IsPlayerSpell(spellID))
 			or IsSpellKnown(spellID)
 			or IsSpellKnown(spellID, 1)
-			or IsSpellKnownOrOverridesKnown(spellID, 0, true)
-			or IsSpellKnownOrOverridesKnown(spellID, 1, true)
+			or IsSpellInSpellBook(spellID, 0, true)
+			or IsSpellInSpellBook(spellID, 1, true)
 			or SpellQuestOverrides[spellID] then
 			return true
 		end
@@ -182,7 +223,6 @@ do
 	function(t) return t.itemID end)
 
 	-- Spell Rank Handling
-	local GetSpellRank = GetSpellRank;
 	local IsRetrieving = app.Modules.RetrievingData.IsRetrieving;
 	local function CacheRankForSpell(spellID, rank)
 		if rank then
@@ -210,7 +250,7 @@ do
 		local IsAccountCached = app.IsAccountCached
 		for id,g in pairs(app.GetRawFieldContainer(KEY)) do
 			-- Cache Spell Names
-			for i,spell in ipairs(g) do
+			for i,spell in app.IterateCachedFieldResults(g) do
 				CacheRankForSpell(id, spell.rank);
 			end
 
@@ -235,33 +275,17 @@ do
 		for specID,spellID in pairs(app.SkillDB.SpecializationSpells) do
 			GetSpellName(spellID);
 		end
-		if GetSpellTabInfo then
-			local lastSpellName, currentSpellRank, lastSpellRank = "", 1, 1;
-			for spellTabIndex=1,GetNumSpellTabs() do
-				local offset, numSlots = select(3, GetSpellTabInfo(spellTabIndex));
-				for spellIndex=offset+1,offset+numSlots do
-					local spellName, _, _, _, _, _, spellID = GetSpellInfo(spellIndex, BOOKTYPE_SPELL);
-					if spellName then
-						saved[spellID] = true
-						currentSpellRank = GetSpellRank(spellID);
-						if not currentSpellRank then
-							if lastSpellName == spellName then
-								currentSpellRank = lastSpellRank + 1;
-							else
-								lastSpellName = spellName;
-								currentSpellRank = 1;
-							end
-						end
-						SpellNameToSpellID[spellName] = spellID;
-						local rankedSpell = RankedSpellNames[spellName];
-						rankedSpell[currentSpellRank] = spellID;
-						if (rankedSpell.max or 0) < currentSpellRank then
-							rankedSpell.max = currentSpellRank;
-						end
-					end
+		IteratePlayerSpellBook(function(spellName, spellID, spellRank)
+			saved[spellID] = true
+			SpellNameToSpellID[spellName] = spellID
+			if spellRank then
+				local rankedSpell = RankedSpellNames[spellName]
+				rankedSpell[spellRank] = spellID
+				if (rankedSpell.max or 0) < spellRank then
+					rankedSpell.max = spellRank
 				end
 			end
-		end
+		end)
 
 		-- If we know a higher rank of the spell, then flag all lower ranks of the spell as collected.
 		for spellName,rankedSpell in pairs(RankedSpellNames) do

--- a/src/Classes/Transmog.lua
+++ b/src/Classes/Transmog.lua
@@ -33,7 +33,6 @@ local GetItemInfoInstant = app.WOWAPI.GetItemInfoInstant;
 local ipairs, select, tinsert, pairs, rawget,rawset
 	= ipairs, select, tinsert, pairs, rawget,rawset
 local C_Item_IsDressableItemByID, GetSlotForInventoryType
----@diagnostic disable-next-line: deprecated
 	= C_Item.IsDressableItemByID, C_Transmog.GetSlotForInventoryType
 local IsRetrieving = app.Modules.RetrievingData.IsRetrieving;
 local L, contains, containsAny, SearchForField
@@ -527,11 +526,83 @@ app.AddRemovalTypeHandler("ItemWithAppearance", function(t)
 	app.UpdateRawID(tkey, tval)
 end)
 
-local VisualIDSourceIDsCache = setmetatable({}, { __index = function(t, visualID)
-	local sourceIDs = C_TransmogCollection_GetAllAppearanceSources(visualID)
-	t[visualID] = sourceIDs or app.EmptyTable
-	return sourceIDs
-end})
+local VisualIDSourceIDsCache = setmetatable({}, {
+	__mode = "v",
+	__index = function(t, visualID)
+		local sourceIDs = C_TransmogCollection_GetAllAppearanceSources(visualID)
+		if sourceIDs then
+			t[visualID] = sourceIDs
+			return sourceIDs
+		end
+		return app.EmptyTable
+	end,
+})
+-- Returns whether the account knows the appearance represented by a SourceID.
+-- This checks the exact source and every other source sharing the same visual so
+-- tooltips correctly identify appearances unlocked from a different item variant.
+app.IsAppearanceKnown = function(sourceID)
+	if not sourceID or not AccountSources then return end
+	if AccountSources[sourceID] or AccountUniqueSources[sourceID] then return true end
+	local sourceInfo = C_TransmogCollection_GetSourceInfo(sourceID)
+	if not sourceInfo or not sourceInfo.visualID then return end
+	if sourceInfo.isCollected then return true end
+	for _,otherSourceID in ipairs(VisualIDSourceIDsCache[sourceInfo.visualID]) do
+		if AccountSources[otherSourceID] then return true end
+		local otherSourceInfo = C_TransmogCollection_GetSourceInfo(otherSourceID)
+		if otherSourceInfo and otherSourceInfo.isCollected then return true end
+	end
+end
+if app.ProfileWrap then
+	app.IsAppearanceKnown = app.ProfileWrap("Transmog.IsAppearanceKnown", app.IsAppearanceKnown)
+end
+
+-- Appends characters for which ATT recorded acquisition of this appearance.
+-- Existing account-wide appearances may not have an owner because Blizzard does not
+-- expose historical acquisition characters; new source-added events are recorded below.
+app.GetAppearanceKnownCharacters = function(sourceID, results)
+	results = results or {}
+	if not sourceID or not CharacterData then return results end
+	local sourceInfo = C_TransmogCollection_GetSourceInfo(sourceID)
+	local visualID = sourceInfo and sourceInfo.visualID
+	local sourceSet = { [sourceID] = true }
+	if visualID then
+		for _,otherSourceID in ipairs(VisualIDSourceIDsCache[visualID]) do
+			sourceSet[otherSourceID] = true
+		end
+	end
+	local seen = {}
+	for guid,character in pairs(CharacterData) do
+		local knownAppearance = visualID and character.KnownAppearances and character.KnownAppearances[visualID]
+		if not knownAppearance then
+			-- Preserve compatibility with older ATT builds which stored SourceIDs per character.
+			local transmog = character.Transmog
+			if transmog then
+				for knownSourceID in pairs(sourceSet) do
+					if transmog[knownSourceID] then
+						knownAppearance = true
+						break
+					end
+				end
+			end
+		end
+		if knownAppearance and not seen[guid] then
+			seen[guid] = true
+			results[#results + 1] = character
+		end
+	end
+	return results
+end
+
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Appearance source arrays", function()
+		local entries, sourceIDs = 0, 0
+		for _,sources in pairs(VisualIDSourceIDsCache) do
+			entries = entries + 1
+			if type(sources) == "table" then sourceIDs = sourceIDs + #sources end
+		end
+		return entries, sourceIDs, "visual IDs / source-ID references"
+	end)
+end
 local CurrentCharacterFilterIDSet
 local ArmorTypeMogs = {
 	[2] = true,	-- Cosmetic
@@ -1011,11 +1082,21 @@ end
 
 -- Whenever we can't find a SourceID in ATT data, create a cached version of it so we can keep resolved data
 -- instead of always generating new
-local UnknownAppearancesCache = setmetatable({}, { __index = function(t, sourceID)
-	local sourceGroup = app.CreateItemSource(sourceID)
-	t[sourceID] = sourceGroup
-	return sourceGroup
-end})
+local UnknownAppearancesCache = setmetatable({}, {
+	__mode = "v",
+	__index = function(t, sourceID)
+		local sourceGroup = app.CreateItemSource(sourceID)
+		t[sourceID] = sourceGroup
+		return sourceGroup
+	end,
+})
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Unknown appearances", function()
+		local entries = 0
+		for _ in pairs(UnknownAppearancesCache) do entries = entries + 1 end
+		return entries, entries, "generated appearance placeholders"
+	end)
+end
 local function GetLinkTooltipInfo(sourceGroup, useItemIDs, sameItem)
 	local sourceID = sourceGroup.sourceID
 	-- when the link never resolves, this link lookup triggers CanRetry prior to being checked below
@@ -1304,12 +1385,45 @@ app.AddEventHandler("OnNewPopoutGroup", BuildSourceInformationForPopout)
 
 -- Event Handling
 app.AddEventRegistration("TRANSMOG_COLLECTION_SOURCE_ADDED", function(sourceID)
+	if app.InvalidateKnownByCache then app.InvalidateKnownByCache("appearance") end
+	-- Remember the visual once per character rather than every shared SourceID.
+	-- This restores owner attribution with far less SavedVariables memory.
+	local sourceInfo = sourceID and C_TransmogCollection_GetSourceInfo(sourceID)
+	local visualID = sourceInfo and sourceInfo.visualID
+	if visualID and app.SetCached then
+		app.SetCached("KnownAppearances", visualID, 1)
+	end
 	-- app.PrintDebug("TRANSMOG_COLLECTION_SOURCE_ADDED",sourceID)
 	app.SetThingCollected("sourceID", sourceID, true, true)
 end)
 app.AddEventRegistration("TRANSMOG_COLLECTION_SOURCE_REMOVED", function(sourceID)
+	if app.InvalidateKnownByCache then app.InvalidateKnownByCache("appearance") end
+	local sourceInfo = sourceID and C_TransmogCollection_GetSourceInfo(sourceID)
+	local visualID = sourceInfo and sourceInfo.visualID
 	-- app.PrintDebug("TRANSMOG_COLLECTION_SOURCE_REMOVED",sourceID)
 	app.SetThingCollected("sourceID", sourceID, true)
+	-- The event may fire before Blizzard's appearance state settles. Clear owner
+	-- attribution only if no source sharing the visual remains known afterward.
+	if visualID and CharacterData and app.CallbackHandlers then
+		app.CallbackHandlers.DelayedCallback(function()
+			if app.InvalidateKnownByCache then app.InvalidateKnownByCache("appearance") end
+			if app.IsAppearanceKnown(sourceID) then return end
+			local sharedSources = VisualIDSourceIDsCache[visualID]
+			for _,character in pairs(CharacterData) do
+				if character.KnownAppearances then character.KnownAppearances[visualID] = nil end
+				if character.Transmog then
+					for _,sharedSourceID in ipairs(sharedSources) do
+						character.Transmog[sharedSourceID] = nil
+					end
+				end
+			end
+		end, 0.5)
+	end
+end)
+
+app.AddEventHandler("OnMemoryCleanup", function()
+	wipe(VisualIDSourceIDsCache)
+	wipe(UnknownAppearancesCache)
 end)
 
 app.AddEventHandler("OnLoad", function()
@@ -1349,6 +1463,7 @@ app.AddEventHandler("OnStartup", function()
 end);
 app.AddEventHandler("OnSavedVariablesAvailable", function(currentCharacter, accountWideData)
 	ATTAccountWideData = accountWideData
+	if not currentCharacter.KnownAppearances then currentCharacter.KnownAppearances = {}; end
 	if not accountWideData.Sources then accountWideData.Sources = {}; end
 	AccountSources = ATTAccountWideData.Sources
 

--- a/src/Classes/base.lua
+++ b/src/Classes/base.lua
@@ -968,7 +968,7 @@ app.WrapObject = function(object, baseObject)
 	});
 end
 
-local ClassDataCaches = {}
+local ClassDataCaches, AllCreatedCaches, AllCreatedCacheNames = {}, {}, {}
 -- Create a local cache table which can be used by a Type class of a Thing to easily store shared
 -- information based on a unique key field for any Thing object of that Type
 app.CreateCache = function(idField, className)
@@ -999,26 +999,37 @@ app.CreateCache = function(idField, className)
 		app.PrintDebug("CACHE_MISS_ID",idField,">",id)
 	end
 	cache.GetCachedField = function(t, field, default_function)
-		--[[ -- Debug Prints
-		local _t, id = cache.GetCached(t);
-		app.PrintDebug("GetCachedField",t.hash,id,field,_t[field]);
-		--]]
-		_t = cache.GetCached(t);
-		if _t then
-			-- set a default provided cache value if any default function was provided and evalutes to a value
-			v = _t[field];
-			if v ~= nil then return v end
-
-			default_function = default_function or DefaultFunctions[field]
-			if not default_function then return end
-
-			local defVal = default_function(t, field, _t);
-			if defVal then
-				v = defVal;
-				_t[field] = v;
-			end
-			return v
+		-- Avoid allocating a permanent per-ID table for a read which has no cached or default value.
+		local id = t[idField]
+		if not id then
+			app.PrintDebug("CACHE_MISS",idField,">",id,t.__type,t.hash)
+			app.PrintTable(t)
+			return
 		end
+		local data = cache[id]
+		if data then
+			v = data[field]
+			if v ~= nil then return v end
+		end
+
+		default_function = default_function or DefaultFunctions[field]
+		if not default_function then return end
+
+		-- Store the table while evaluating the default so existing default functions which call
+		-- cache.GetCached(t) write into this same entry. Remove it afterward only if it stayed empty.
+		if not data then
+			data = {}
+			cache[id] = data
+		end
+		local defVal = default_function(t, field, data)
+		if defVal then
+			v = defVal
+			data[field] = v
+		else
+			v = nil
+			if next(data) == nil then cache[id] = nil end
+		end
+		return v
 	end
 	cache.SetCachedField = function(t, field, value)
 		--[[ Debug Prints
@@ -1033,6 +1044,8 @@ app.CreateCache = function(idField, className)
 		if _t then _t[field] = value; end
 	end
 	cache.DefaultFunctions = DefaultFunctions
+	AllCreatedCaches[#AllCreatedCaches + 1] = cache
+	AllCreatedCacheNames[#AllCreatedCacheNames + 1] = className or idField or ("Cache " .. #AllCreatedCaches)
 	if app.__perf then
 		return app.__perf.CaptureTable(cache, "ClassCache:"..(className or idField))
 	end
@@ -1047,6 +1060,61 @@ app.GetOrCreateCache = function(idField, className)
 
 	app.print("Missing className",className,"for ClassData cache with idField",idField)
 	return app.CreateCache(idField, className)
+end
+
+local function PruneEmptyClassCaches()
+	for i=1,#AllCreatedCaches do
+		local cache = AllCreatedCaches[i]
+		local defaults = cache.DefaultFunctions
+		for id,data in pairs(cache) do
+			if type(data) == "table" and data ~= defaults and next(data) == nil then
+				cache[id] = nil
+			end
+		end
+	end
+end
+app.AddEventHandler("OnMemoryCleanup", PruneEmptyClassCaches)
+
+app.GetClassCacheMemoryStats = function()
+	local entries, empty = 0, 0
+	for i=1,#AllCreatedCaches do
+		local cache = AllCreatedCaches[i]
+		local defaults = cache.DefaultFunctions
+		for _,data in pairs(cache) do
+			if type(data) == "table" and data ~= defaults then
+				entries = entries + 1
+				if next(data) == nil then empty = empty + 1 end
+			end
+		end
+	end
+	return #AllCreatedCaches, entries, empty
+end
+
+app.GetClassCacheMemoryDetailStats = function()
+	local details = {}
+	for i=1,#AllCreatedCaches do
+		local cache = AllCreatedCaches[i]
+		local defaults = cache.DefaultFunctions
+		local entries, fields, empty = 0, 0, 0
+		for _,data in pairs(cache) do
+			if type(data) == "table" and data ~= defaults then
+				entries = entries + 1
+				local hasField
+				for _ in pairs(data) do
+					fields = fields + 1
+					hasField = true
+				end
+				if not hasField then empty = empty + 1 end
+			end
+		end
+		details[#details + 1] = {
+			name = AllCreatedCacheNames[i],
+			entries = entries,
+			fields = fields,
+			empty = empty,
+		}
+	end
+	return details
 end
 
 -- Allows creating a group which is keyed based on only its 'name' field

--- a/src/Expansions/Dragonflight.lua
+++ b/src/Expansions/Dragonflight.lua
@@ -84,7 +84,7 @@ do
 		local saved, none = {}, {}
 		local o
 		for id,cache in pairs(app.GetRawFieldContainer(KEY)) do
-			o = cache[1]
+			o = app.GetFirstCachedFieldResult(cache)
 			-- If saved, then the FC is cached
 			if o.saved then
 				saved[id] = true

--- a/src/Expansions/Legion.lua
+++ b/src/Expansions/Legion.lua
@@ -24,7 +24,7 @@ local pairs, select, math_floor,tinsert,tremove
 local L, ColorizeRGB, contains, CloneDictionary
 	= app.L, app.Modules.Color.ColorizeRGB, app.contains, app.CloneDictionary
 local GetRelativeField = app.GetRelativeField
-local GetDetailedItemLevelInfo = GetDetailedItemLevelInfo;
+local GetDetailedItemLevelInfo = app.WOWAPI.GetDetailedItemLevelInfo;
 local ArtifactDB = setmetatable(app.ArtifactDB or {}, { __index = function(t,key)
 	app.PrintDebug("ArtifactID not in DB!",key)
 	t[key] = app.EmptyTable

--- a/src/Modules/Contributor.lua
+++ b/src/Modules/Contributor.lua
@@ -3547,11 +3547,24 @@ AddEventFunc("QUEST_COMPLETE", OnQUEST_DETAIL)
 -- PLAYER_SOFT_INTERACT_CHANGED
 -- Whenever we can't find a ObjectID in ATT data, create a cached version of it so we can keep resolved data
 -- instead of always generating new
-local UnknownObjectsCache = setmetatable({}, { __index = function(t, objectID)
-	local o = app.CreateObject(objectID)
-	t[objectID] = o
-	return o
-end})
+local UnknownObjectsCache = setmetatable({}, {
+	__mode = "v",
+	__index = function(t, objectID)
+		local o = app.CreateObject(objectID)
+		t[objectID] = o
+		return o
+	end,
+})
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Unknown objects", function()
+		local entries = 0
+		for _ in pairs(UnknownObjectsCache) do entries = entries + 1 end
+		return entries, entries, "generated object placeholders"
+	end)
+end
+app.AddEventHandler("OnMemoryCleanup", function()
+	wipe(UnknownObjectsCache)
+end)
 local LastSoftInteract = {}
 local RegisterUNIT_SPELLCAST_SENT, UnregisterUNIT_SPELLCAST_SENT
 -- Allows automatically tracking nearby ObjectID's and running check functions on them for data verification

--- a/src/Modules/Costs.lua
+++ b/src/Modules/Costs.lua
@@ -472,17 +472,17 @@ local function UpdateCosts()
 
 	-- Get all itemIDAsCost entries
 	for itemID,refs in pairs(app.GetFieldContainer("itemIDAsCost")) do
-		UpdateRunner.Run(UpdateCostsByItemID, itemID, refresh, false, refs)
+		UpdateRunner.Run(UpdateCostsByItemID, itemID, refresh, false, app.GetCachedFieldResults(refs, true))
 	end
 
 	-- Get all currencyIDAsCost entries
 	for currencyID,refs in pairs(app.GetFieldContainer("currencyIDAsCost")) do
-		UpdateRunner.Run(UpdateCostsByCurrencyID, currencyID, refresh, false, refs)
+		UpdateRunner.Run(UpdateCostsByCurrencyID, currencyID, refresh, false, app.GetCachedFieldResults(refs, true))
 	end
 
 	-- Get all spellIDAsCost entries
 	for spellID,refs in pairs(app.GetFieldContainer("spellIDAsCost")) do
-		UpdateRunner.Run(UpdateCostsBySpellID, spellID, refresh, false, refs)
+		UpdateRunner.Run(UpdateCostsBySpellID, spellID, refresh, false, app.GetCachedFieldResults(refs, true))
 	end
 end
 

--- a/src/Modules/Memory.lua
+++ b/src/Modules/Memory.lua
@@ -1,0 +1,398 @@
+-- Memory diagnostics, delayed cleanup, automatic zone maintenance, and search-index maintenance for ATT.
+local appName, app = ...
+
+local collectgarbage, pcall, type, pairs = collectgarbage, pcall, type, pairs
+local sort = table.sort
+local GetAddOnMemoryUsage, UpdateAddOnMemoryUsage = GetAddOnMemoryUsage, UpdateAddOnMemoryUsage
+local After = C_Timer and C_Timer.After
+local InCombatLockdown = InCombatLockdown
+
+app.DesignateImmediateEvent("OnMemoryCleanup")
+
+local ZONE_CLEANUP_DELAY = 12
+local SECOND_STARTUP_CLEANUP_DELAY = 60
+local COMBAT_RETRY_DELAY = 10
+local ZONE_MEMORY_THRESHOLD_KB = 30 * 1024
+local DETAIL_DEFAULT_LIMIT = 15
+local GC_STEP_SIZE = 4096
+local GC_MAX_STEPS = 180
+
+local startupCleanupScheduled, startupCleanupComplete, secondStartupCleanupScheduled
+local zoneCleanupGeneration = 0
+local lastZoneMapID
+local lastZoneCleanup
+local lastCleanMemoryKB
+local lastIndexMaintenanceGeneration = -1
+local incrementalGCRunning, incrementalGCSteps = false, 0
+local incrementalGCCompletions = {}
+
+local function GetMemoryKB()
+	if UpdateAddOnMemoryUsage and GetAddOnMemoryUsage then
+		UpdateAddOnMemoryUsage()
+		local value = GetAddOnMemoryUsage(appName)
+		if type(value) == "number" then return value end
+	end
+	if collectgarbage then
+		local ok, value = pcall(collectgarbage, "count")
+		if ok and type(value) == "number" then return value end
+	end
+end
+
+local function FormatMemory(kb)
+	if not kb then return "unavailable" end
+	return ("%.1f MB"):format(kb / 1024)
+end
+
+local function CollectMemoryFull()
+	if not collectgarbage then return end
+	local started = app.ProfileStartTimer and app.ProfileStartTimer()
+	pcall(collectgarbage, "collect")
+	pcall(collectgarbage, "collect")
+	if app.ProfileStopTimer then app.ProfileStopTimer("Memory.FullGC", started) end
+end
+
+local function FinishIncrementalGC()
+	incrementalGCRunning = false
+	local completions = incrementalGCCompletions
+	incrementalGCCompletions = {}
+	for i=1,#completions do completions[i]() end
+end
+
+local function RunIncrementalGCStep()
+	if not incrementalGCRunning then return end
+	local started = app.ProfileStartTimer and app.ProfileStartTimer()
+	local ok, complete = pcall(collectgarbage, "step", GC_STEP_SIZE)
+	if app.ProfileStopTimer then app.ProfileStopTimer("Memory.IncrementalGCStep", started) end
+	incrementalGCSteps = incrementalGCSteps + 1
+	if not ok then
+		CollectMemoryFull()
+		FinishIncrementalGC()
+		return
+	end
+	if complete or incrementalGCSteps >= GC_MAX_STEPS then
+		FinishIncrementalGC()
+	elseif After then
+		After(0, RunIncrementalGCStep)
+	else
+		CollectMemoryFull()
+		FinishIncrementalGC()
+	end
+end
+
+-- Automatic maintenance uses bounded GC work over multiple frames to avoid a large
+-- zone/login hitch. Multiple cleanups share the active cycle and each receives completion.
+local function CollectMemoryIncremental(onComplete)
+	if onComplete then incrementalGCCompletions[#incrementalGCCompletions + 1] = onComplete end
+	if incrementalGCRunning then return end
+	if not collectgarbage then
+		FinishIncrementalGC()
+		return
+	end
+	incrementalGCRunning = true
+	incrementalGCSteps = 0
+	if After then After(0, RunIncrementalGCStep) else RunIncrementalGCStep() end
+end
+
+local function RunCacheCleanupEvent()
+	local started = app.ProfileStartTimer and app.ProfileStartTimer()
+	app.HandleEvent("OnMemoryCleanup")
+	if app.ProfileStopTimer then app.ProfileStopTimer("Memory.ClearTransientCaches", started) end
+end
+
+local function GetIndexGeneration()
+	local getGeneration = app.GetSearchIndexGeneration
+	return getGeneration and getGeneration() or 0
+end
+
+local function CleanSearchIndex(force)
+	local generation = GetIndexGeneration()
+	if not force and generation == lastIndexMaintenanceGeneration then
+		return { 0, 0, 0, 0, 0, 0 }, false
+	end
+	local clean = app.CleanSearchIndex
+	local stats = clean and { clean() } or { 0, 0, 0, 0, 0, 0 }
+	lastIndexMaintenanceGeneration = GetIndexGeneration()
+	return stats, true
+end
+
+local function PrintIndexCleanup(stats, prefix)
+	if not stats then return end
+	app.print(prefix or "Search index cleanup:", stats[1] or 0, "keys and", stats[2] or 0,
+		"references scanned;", stats[3] or 0, "keys and", stats[4] or 0,
+		"duplicate/invalid references removed;", stats[5] or 0, "lists demoted;",
+		stats[6] or 0, "empty field containers removed.")
+end
+
+local function PrintCacheStats()
+	local GetCacheMemoryStats = app.GetCacheMemoryStats
+	if not GetCacheMemoryStats then return end
+	local fields, keys, singletons, lists, references = GetCacheMemoryStats()
+	app.print("Compact search index:", keys, "keys;", singletons, "singletons;", lists, "shared-key arrays;", references, "object references across", fields, "fields.")
+	local GetClassCacheMemoryStats = app.GetClassCacheMemoryStats
+	if GetClassCacheMemoryStats then
+		local caches, entries, empty = GetClassCacheMemoryStats()
+		app.print("Class property caches:", caches, "caches;", entries, "ID entries;", empty, "empty entries.")
+	end
+	if lastCleanMemoryKB then
+		app.print("Automatic-clean baseline:", FormatMemory(lastCleanMemoryKB), "; zone cleanup threshold:", FormatMemory(ZONE_MEMORY_THRESHOLD_KB), "above baseline.")
+	end
+	if lastZoneCleanup then
+		if lastZoneCleanup.skipped then
+			app.print("Last zone auto-clean: skipped on map", lastZoneCleanup.mapID or 0,
+				"at", FormatMemory(lastZoneCleanup.before), "(", FormatMemory(lastZoneCleanup.increase or 0), "above baseline; index unchanged).")
+		else
+			app.print("Last zone auto-clean:", FormatMemory(lastZoneCleanup.before), "->", FormatMemory(lastZoneCleanup.after),
+				"on map", lastZoneCleanup.mapID or 0, ";", lastZoneCleanup.removedReferences or 0,
+				"index references removed; transient cleanup", lastZoneCleanup.cleanedMemory and "ran." or "was not needed.")
+		end
+	end
+end
+
+local function PrintMemoryDetail(showAll)
+	app.print("Memory detail uses entry/reference counts; Lua does not expose exact bytes per individual table.")
+
+	local getIndexDetails = app.GetCacheMemoryDetailStats
+	if getIndexDetails then
+		local details = getIndexDetails()
+		sort(details, function(a, b)
+			if a.references == b.references then
+				if a.keys == b.keys then return tostring(a.field) < tostring(b.field) end
+				return a.keys > b.keys
+			end
+			return a.references > b.references
+		end)
+		local limit = showAll and #details or math.min(DETAIL_DEFAULT_LIMIT, #details)
+		app.print("Search-index fields:", limit, "shown of", #details, "sorted by retained references.")
+		for i=1,limit do
+			local d = details[i]
+			app.print(("  %s.%s: %d keys; %d refs; %d singleton; %d shared arrays"):format(
+				tostring(d.cache), tostring(d.field), d.keys or 0, d.references or 0,
+				d.singletons or 0, d.lists or 0))
+		end
+		if not showAll and #details > limit then
+			app.print("Use /att memory detail all to show every indexed field.")
+		end
+	end
+
+	local getClassDetails = app.GetClassCacheMemoryDetailStats
+	if getClassDetails then
+		local details = getClassDetails()
+		sort(details, function(a, b)
+			if a.entries == b.entries then return tostring(a.name) < tostring(b.name) end
+			return a.entries > b.entries
+		end)
+		app.print("Class-property caches:", #details, "caches.")
+		for i=1,#details do
+			local d = details[i]
+			app.print(("  %s: %d IDs; %d cached fields; %d empty"):format(
+				tostring(d.name), d.entries or 0, d.fields or 0, d.empty or 0))
+		end
+	end
+
+	local getProviders = app.GetRegisteredMemoryCacheStats
+	local providers = getProviders and getProviders()
+	if providers then
+		local names = {}
+		for name in pairs(providers) do names[#names + 1] = name end
+		sort(names)
+		app.print("Transient/rebuildable caches:", #names, "providers.")
+		for i=1,#names do
+			local name = names[i]
+			local ok, entries, references, note = pcall(providers[name])
+			if ok then
+				app.print(("  %s: %d entries; %d retained refs%s"):format(
+					name, entries or 0, references or 0, note and (" (" .. note .. ")") or ""))
+			else
+				app.print("  ", name, ": diagnostic unavailable")
+			end
+		end
+	end
+end
+
+local function RunSecondStartupCleanup()
+	if InCombatLockdown and InCombatLockdown() then
+		if After then After(COMBAT_RETRY_DELAY, RunSecondStartupCleanup) end
+		return
+	end
+	local before = GetMemoryKB()
+	RunCacheCleanupEvent()
+	CleanSearchIndex(false)
+	CollectMemoryIncremental(function()
+		local after = GetMemoryKB()
+		lastCleanMemoryKB = after or before or lastCleanMemoryKB
+		if before and after and before - after >= 5120 then
+			app.print("Delayed startup memory optimized:", FormatMemory(before), "->", FormatMemory(after))
+		end
+	end)
+end
+
+local function RunStartupCleanup()
+	if InCombatLockdown and InCombatLockdown() then
+		if After then After(COMBAT_RETRY_DELAY, RunStartupCleanup) end
+		return
+	end
+	local before = GetMemoryKB()
+	RunCacheCleanupEvent()
+	CleanSearchIndex(true)
+	CollectMemoryIncremental(function()
+		local after = GetMemoryKB()
+		startupCleanupComplete = true
+		lastZoneMapID = app.CurrentMapID
+		lastCleanMemoryKB = after or before
+		if before and after and before - after >= 5120 then
+			app.print("Startup memory optimized:", FormatMemory(before), "->", FormatMemory(after))
+		end
+		if not secondStartupCleanupScheduled then
+			secondStartupCleanupScheduled = true
+			if After then After(SECOND_STARTUP_CLEANUP_DELAY, RunSecondStartupCleanup) end
+		end
+	end)
+end
+
+-- Startup collection scans create short-lived search arrays and API result tables. Release them
+-- once the first collection refresh is complete instead of retaining the login-time peak.
+app.AddEventHandler("OnRefreshCollectionsDone", function()
+	if startupCleanupScheduled then return end
+	startupCleanupScheduled = true
+	if After then After(5, RunStartupCleanup) else RunStartupCleanup() end
+end)
+
+local function RunZoneCleanup(generation, mapID)
+	if generation ~= zoneCleanupGeneration or mapID ~= app.CurrentMapID then return end
+	if InCombatLockdown and InCombatLockdown() then
+		if After then
+			After(COMBAT_RETRY_DELAY, function()
+				RunZoneCleanup(generation, mapID)
+			end)
+		end
+		return
+	end
+
+	local before = GetMemoryKB()
+	local baseline = lastCleanMemoryKB or before
+	local increase = before and baseline and before - baseline or 0
+	local indexChanged = GetIndexGeneration() ~= lastIndexMaintenanceGeneration
+	local shouldCleanMemory = not baseline or increase >= ZONE_MEMORY_THRESHOLD_KB
+
+	if not shouldCleanMemory and not indexChanged then
+		lastZoneCleanup = {
+			before = before, after = before, increase = increase, mapID = mapID,
+			removedReferences = 0, cleanedMemory = false, skipped = true,
+		}
+		return
+	end
+
+	if shouldCleanMemory then RunCacheCleanupEvent() end
+	local indexStats = { 0, 0, 0, 0, 0, 0 }
+	if indexChanged then indexStats = (select(1, CleanSearchIndex(false))) end
+
+	local function FinalizeZoneCleanup()
+		local after = GetMemoryKB()
+		if shouldCleanMemory or (indexStats[4] or 0) > 0 then
+			lastCleanMemoryKB = after or before or lastCleanMemoryKB
+		end
+		lastZoneCleanup = {
+			before = before, after = after, increase = increase, mapID = mapID,
+			removedReferences = indexStats[4] or 0, cleanedMemory = shouldCleanMemory, skipped = false,
+		}
+		if before and after and before - after >= 10240 then
+			app.print("Zone memory optimized:", FormatMemory(before), "->", FormatMemory(after))
+		end
+	end
+
+	if shouldCleanMemory or (indexStats[4] or 0) > 0 or (indexStats[5] or 0) > 0 then
+		CollectMemoryIncremental(FinalizeZoneCleanup)
+	else
+		FinalizeZoneCleanup()
+	end
+end
+
+-- OnCurrentMapIDChanged only fires when ATT resolves a genuinely different map ID. Debounce
+-- maintenance so the Mini List and delayed zone scans can finish before transient data is released.
+app.AddEventHandler("OnCurrentMapIDChanged", function()
+	if not startupCleanupComplete then return end
+	local mapID = app.CurrentMapID
+	if not mapID or mapID == 0 or mapID == lastZoneMapID then return end
+	lastZoneMapID = mapID
+	zoneCleanupGeneration = zoneCleanupGeneration + 1
+	local generation = zoneCleanupGeneration
+	if After then
+		After(ZONE_CLEANUP_DELAY, function()
+			RunZoneCleanup(generation, mapID)
+		end)
+	else
+		RunZoneCleanup(generation, mapID)
+	end
+end)
+
+local function RunManualCleanup(before)
+	RunCacheCleanupEvent()
+	local indexStats = select(1, CleanSearchIndex(true))
+	CollectMemoryFull()
+	local after = GetMemoryKB()
+	lastCleanMemoryKB = after or before
+	app.print("Memory cleanup:", FormatMemory(before), "->", FormatMemory(after))
+	if before and after then
+		local released = before - after
+		app.print("Transient memory released:", FormatMemory(released > 0 and released or 0))
+	end
+	PrintIndexCleanup(indexStats)
+	PrintCacheStats()
+end
+
+local function RunIndexRebuild(before)
+	if InCombatLockdown and InCombatLockdown() then
+		app.print("Search index rebuild is unavailable during combat. Try again after combat ends.")
+		return
+	end
+	RunCacheCleanupEvent()
+	local rebuild = app.RebuildSearchIndex
+	if not rebuild then
+		app.print("Search index rebuild function is unavailable.")
+		return
+	end
+	local stats = { rebuild() }
+	lastIndexMaintenanceGeneration = GetIndexGeneration()
+	CollectMemoryFull()
+	local after = GetMemoryKB()
+	lastCleanMemoryKB = after or before
+	app.print("Search index rebuilt:", stats[1] or 0, "fields;", stats[2] or 0, "keys;",
+		stats[3] or 0, "object references;", stats[4] or 0, "empty keys and",
+		stats[5] or 0, "duplicate/invalid references removed.")
+	app.print("Index rebuild memory:", FormatMemory(before), "->", FormatMemory(after))
+	PrintCacheStats()
+end
+
+app.ChatCommands.Add({ "memory", "mem" }, function(args)
+	local before = GetMemoryKB()
+	local operation = args and args[1] and args[1]:lower()
+	local suboperation = args and args[2] and args[2]:lower()
+	if operation == "clean" or operation == "cleanup" or operation == "gc" then
+		RunManualCleanup(before)
+	elseif operation == "detail" or operation == "details" then
+		app.print("Current ATT memory:", FormatMemory(before))
+		PrintCacheStats()
+		PrintMemoryDetail(suboperation == "all")
+	elseif operation == "rebuild" or (operation == "index" and suboperation == "rebuild") then
+		RunIndexRebuild(before)
+	elseif operation == "index" and (suboperation == "clean" or suboperation == "cleanup") then
+		local stats = select(1, CleanSearchIndex(true))
+		CollectMemoryFull()
+		local after = GetMemoryKB()
+		lastCleanMemoryKB = after or before
+		PrintIndexCleanup(stats)
+		app.print("Index cleanup memory:", FormatMemory(before), "->", FormatMemory(after))
+		PrintCacheStats()
+	elseif operation == "index" or operation == "stats" then
+		app.print("Current ATT memory:", FormatMemory(before))
+		PrintCacheStats()
+	else
+		app.print("Current ATT memory:", FormatMemory(before))
+		PrintCacheStats()
+		app.print("Use /att memory detail for cache diagnostics, /att memory clean for transient cleanup, or /att memory index rebuild for a full key-index rebuild.")
+	end
+	return true
+end, {
+	"Usage : /att memory [clean|detail|detail all|index|index clean|index rebuild]",
+	"Reports ATT memory and cache statistics. A second delayed login cleanup runs after startup. Zone changes only purge transient caches after memory grows 30 MB above the last clean baseline, and only compact the key index when it changed.",
+})

--- a/src/Modules/Performance.lua
+++ b/src/Modules/Performance.lua
@@ -1,0 +1,181 @@
+-- Lightweight, opt-in runtime profiler for ATT hot paths.
+-- Unlike the contributor PerformanceTracking.lua harness, this remains dormant until
+-- /att profile start and adds only a single boolean branch to wrapped functions.
+local appName, app = ...
+
+local debugprofilestop = debugprofilestop
+local GetTimePreciseSec = GetTimePreciseSec
+local pairs, type, tostring, select = pairs, type, tostring, select
+local sort, unpack = table.sort, unpack or table.unpack
+local pack = table.pack or function(...)
+	return { n = select("#", ...), ... }
+end
+
+local active = false
+local sessionStarted
+local statistics = {}
+local wrapped = setmetatable({}, { __mode = "k" })
+local DEFAULT_REPORT_LIMIT = 25
+
+local function NowMilliseconds()
+	if debugprofilestop then return debugprofilestop() end
+	return (GetTimePreciseSec and GetTimePreciseSec() or 0) * 1000
+end
+
+local function GetStat(name)
+	local stat = statistics[name]
+	if not stat then
+		stat = { count = 0, total = 0, max = 0 }
+		statistics[name] = stat
+	end
+	return stat
+end
+
+local function Record(name, elapsed)
+	if not active or not name then return end
+	local stat = GetStat(name)
+	stat.count = stat.count + 1
+	stat.total = stat.total + (elapsed or 0)
+	if elapsed and elapsed > stat.max then stat.max = elapsed end
+end
+
+app.ProfileIsActive = function()
+	return active
+end
+
+app.ProfileStartTimer = function()
+	if active then return NowMilliseconds() end
+end
+
+app.ProfileStopTimer = function(name, started)
+	if active and started then Record(name, NowMilliseconds() - started) end
+end
+
+app.ProfileCount = function(name, count)
+	if not active or not name then return end
+	local stat = GetStat(name)
+	stat.count = stat.count + (count or 1)
+end
+
+-- Wraps a function while preserving all return values. Result packing occurs only while
+-- profiling is enabled, so normal gameplay does not create temporary result tables.
+app.ProfileWrap = function(name, func)
+	if type(func) ~= "function" then return func end
+	local existing = wrapped[func]
+	if existing then return existing end
+	local wrapper = function(...)
+		if not active then return func(...) end
+		local started = NowMilliseconds()
+		local results = pack(func(...))
+		Record(name, NowMilliseconds() - started)
+		return unpack(results, 1, results.n)
+	end
+	wrapped[func] = wrapper
+	wrapped[wrapper] = wrapper
+	return wrapper
+end
+
+local function ResetStatistics()
+	for name in pairs(statistics) do statistics[name] = nil end
+	sessionStarted = active and NowMilliseconds() or nil
+end
+
+local function StartProfiling(reset)
+	if reset ~= false then ResetStatistics() end
+	active = true
+	sessionStarted = NowMilliseconds()
+	app.print("ATT performance profiling started. Use /att profile stop, then /att profile report.")
+end
+
+local function StopProfiling()
+	if not active then
+		app.print("ATT performance profiling is not running.")
+		return
+	end
+	active = false
+	local elapsed = sessionStarted and (NowMilliseconds() - sessionStarted) or 0
+	app.print(("ATT performance profiling stopped after %.1f seconds."):format(elapsed / 1000))
+end
+
+local function ReportProfiling(showAll)
+	local rows = {}
+	for name, stat in pairs(statistics) do
+		rows[#rows + 1] = {
+			name = name,
+			count = stat.count,
+			total = stat.total,
+			max = stat.max,
+			average = stat.count > 0 and stat.total / stat.count or 0,
+		}
+	end
+	sort(rows, function(a, b)
+		if a.total == b.total then
+			if a.count == b.count then return tostring(a.name) < tostring(b.name) end
+			return a.count > b.count
+		end
+		return a.total > b.total
+	end)
+	local limit = showAll and #rows or math.min(DEFAULT_REPORT_LIMIT, #rows)
+	app.print("ATT profile report:", limit, "shown of", #rows, "operations; times are milliseconds.")
+	for i=1,limit do
+		local row = rows[i]
+		app.print(("  %s: %d calls; %.2f total; %.3f avg; %.2f max"):format(
+			row.name, row.count, row.total, row.average, row.max))
+	end
+	if #rows == 0 then
+		app.print("  No samples recorded. Start profiling and use ATT normally before reporting.")
+	elseif not showAll and #rows > limit then
+		app.print("Use /att profile report all to show every recorded operation.")
+	end
+end
+
+app.ChatCommands.Add("profile", function(args)
+	local operation = args and args[1] and args[1]:lower()
+	local option = args and args[2] and args[2]:lower()
+	if operation == "start" then
+		StartProfiling(option ~= "keep")
+	elseif operation == "stop" then
+		StopProfiling()
+	elseif operation == "report" or operation == "show" then
+		ReportProfiling(option == "all")
+	elseif operation == "reset" or operation == "clear" then
+		ResetStatistics()
+		app.print("ATT performance profile data cleared.")
+	elseif operation == "status" then
+		app.print("ATT performance profiling is", active and "running." or "stopped.")
+	else
+		app.print("Usage: /att profile [start|stop|report|report all|reset|status]")
+	end
+	return true
+end, {
+	"Usage : /att profile [start|stop|report|report all|reset|status]",
+	"Runs a lightweight opt-in profiler for ATT searches, symlinks, windows, profession scans, tooltips, and memory maintenance.",
+})
+
+-- Track the complete collection refresh sequence, which may span the ATT event runner.
+local collectionRefreshStarted
+app.AddEventHandler("OnRefreshCollections", function()
+	collectionRefreshStarted = app.ProfileStartTimer()
+end)
+app.AddEventHandler("OnRefreshCollectionsDone", function()
+	app.ProfileStopTimer("Collections.RefreshCycle", collectionRefreshStarted)
+	collectionRefreshStarted = nil
+end)
+app.AddEventHandler("OnCurrentMapIDChanged", function()
+	app.ProfileCount("Map.CurrentMapIDChanged")
+end)
+
+-- Window methods exist by the time OnWindowCreated fires. Wrap only meaningful pipeline
+-- operations and custom hot-path methods; profiling remains inactive by default.
+app.AddEventHandler("OnWindowCreated", function(window, suffix)
+	if not window or window.__ATTProfileWrapped then return end
+	window.__ATTProfileWrapped = true
+	local prefix = "Window." .. tostring(suffix) .. "."
+	local methods = { "Rebuild", "ForceRebuild", "Update", "ForceUpdate", "Refresh", "Redraw", "RefreshRecipes", "RefreshLocation" }
+	for i=1,#methods do
+		local method = methods[i]
+		if type(window[method]) == "function" then
+			window[method] = app.ProfileWrap(prefix .. method, window[method])
+		end
+	end
+end)

--- a/src/Modules/RetrievingData.lua
+++ b/src/Modules/RetrievingData.lua
@@ -58,6 +58,13 @@ end
 
 -- Search Results Lib
 local searchCache, working = {}, nil;
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Retrieval search", function()
+		local entries = 0
+		for _ in pairs(searchCache) do entries = entries + 1 end
+		return entries, entries, "cached search roots"
+	end)
+end
 app.GetCachedData = function(cacheKey, method, ...)
 	if IsRetrieving(cacheKey) then return; end
 	local cache = searchCache[cacheKey];
@@ -85,3 +92,4 @@ app.AddEventHandler("OnThingCollected", WipeSearchCache);
 app.AddEventHandler("OnThingRemoved", WipeSearchCache);
 app.AddEventHandler("OnSettingsRefreshed", WipeSearchCache);
 app.AddEventHandler("Fill.RefreshFillers", WipeSearchCache)
+app.AddEventHandler("OnMemoryCleanup", WipeSearchCache)

--- a/src/Modules/Search.lua
+++ b/src/Modules/Search.lua
@@ -494,12 +494,12 @@ local function BuildSearchResponseViaCacheContainer(cacheContainer, value)
 	-- app.PrintDebug("BSR:Cached",value)
 	if cacheContainer then
 		if value then
-			local sources = cacheContainer[value];
+			local sources = app.GetCachedFieldResults(cacheContainer[value]);
 			BuildClonedHierarchy(sources);
 		else
 			for id,sources in pairs(cacheContainer) do
 				-- each Thing's Sources need to be built
-				BuildClonedHierarchy(sources);
+				BuildClonedHierarchy(app.GetCachedFieldResults(sources));
 			end
 		end
 	end

--- a/src/Modules/Symlink.lua
+++ b/src/Modules/Symlink.lua
@@ -855,19 +855,37 @@ end or function(finalized, searchResults, o, oSym)
 		end
 	end
 end
-local ResolveCache = {};
+-- Resolved symlink data can be very large. Keep it only while another live object/window
+-- still references it instead of retaining every resolved result for the entire session.
+local ResolveCache = setmetatable({}, { __mode = "v" });
+local ObjectResolveCache = setmetatable({}, { __mode = "kv" });
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Symlink results", function()
+		local entries, resolvedObjects = 0, 0
+		for _,results in pairs(ResolveCache) do
+			entries = entries + 1
+			if type(results) == "table" then resolvedObjects = resolvedObjects + #results end
+		end
+		for _,results in pairs(ObjectResolveCache) do
+			entries = entries + 1
+			if type(results) == "table" then resolvedObjects = resolvedObjects + #results end
+		end
+		return entries, resolvedObjects, "cached symlinks / resolved objects"
+	end)
+end
 ResolveSymbolicLink = function(o, refonly)
 	local oSym = o.sym
 	if not oSym then return end
 
 	local oHash, oKey = o.hash, o.key;
-	if o.resolved or (oKey and app.ThingKeys[oKey] and ResolveCache[oHash]) then
+	local cached = ObjectResolveCache[o] or (oKey and app.ThingKeys[oKey] and ResolveCache[oHash]);
+	if cached then
 		if refonly then
-			return o.resolved or ResolveCache[oHash]
+			return cached
 		end
-		-- app.PrintDebug(o.resolved and "Object Resolve" or "Cache Resolve",oHash,#(o.resolved or ResolveCache[oHash]))
+		-- app.PrintDebug(ObjectResolveCache[o] and "Object Resolve" or "Cache Resolve",oHash,#cached)
 		local cloned = {};
-		MergeObjects(cloned, o.resolved or ResolveCache[oHash], true);
+		MergeObjects(cloned, cached, true);
 		return cloned;
 	end
 
@@ -929,14 +947,22 @@ ResolveSymbolicLink = function(o, refonly)
 		-- app.PrintDebug("Thing Results",oHash,#cloned)
 		ResolveCache[oHash] = cloned;
 	elseif oKey ~= false then
-		-- otherwise can store it in the object itself (like a header from the Main list with symlink), if it's not specifically a pseudo-symlink resolve group
-		o.resolved = cloned;
+		-- Non-Thing symlinks are cached by object with a weak value so closed/rebuilt
+		-- windows do not leave their cloned result trees retained for the whole session.
+		ObjectResolveCache[o] = cloned;
 		-- app.PrintDebug("Object Results",oHash,#cloned)
 	end
 	-- app.PrintDebug("Symbolic Link for", oKey,oKey and o[oKey], "contains", #cloned, "values after filtering.")
 	return cloned;
 end
+if app.ProfileWrap then
+	ResolveSymbolicLink = app.ProfileWrap("Symlink.ResolveSymbolicLink", ResolveSymbolicLink)
+end
 app.ResolveSymbolicLink = ResolveSymbolicLink
+app.AddEventHandler("OnMemoryCleanup", function()
+	wipe(ResolveCache)
+	wipe(ObjectResolveCache)
+end)
 
 -- Performance Tracking
 if app.__perf then

--- a/src/Modules/Tooltip.lua
+++ b/src/Modules/Tooltip.lua
@@ -781,6 +781,16 @@ local function WipeTooltipInfoCache()
 	-- app.PrintDebug("WipeTooltipInfoCache")
 end
 app.WipeTooltipInfoCache = WipeTooltipInfoCache
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Tooltip info", function()
+		local entries, lines = 0, 0
+		for _,tooltipInfo in pairs(TooltipInfoCache) do
+			entries = entries + 1
+			if type(tooltipInfo) == "table" then lines = lines + #tooltipInfo end
+		end
+		return entries, lines, "cached tooltips / tooltip lines"
+	end)
+end
 -- app.AddEventHandler("OnCurrentDifficultiesChanged", WipeTooltipInfoCache);
 -- app.AddEventHandler("OnRefreshComplete", WipeTooltipInfoCache);
 -- app.AddEventHandler("OnThingCollected", WipeTooltipInfoCache);
@@ -880,7 +890,6 @@ if TooltipDataProcessor and app.GameBuildVersion > 60000 then
 	-- 10.0.2
 	-- https://wowpedia.fandom.com/wiki/Patch_10.0.2/API_changes#Tooltip_Changes
 	-- many of these don't include an ID in-game so they don't attach results. maybe someday they will...
-	---@diagnostic disable-next-line: deprecated
 	local Enum_TooltipDataType, TooltipUtil = Enum.TooltipDataType, TooltipUtil;
 
 	local function SafelyCheckTooltipForUnitInfo(tooltip)

--- a/src/Modules/Upgrade.lua
+++ b/src/Modules/Upgrade.lua
@@ -505,7 +505,14 @@ local function GetNextItemUnlockBonusID(item)
 end
 api.GetNextItemUnlockBonusID = GetNextItemUnlockBonusID;
 
-local ItemSourceCache = {}
+local ItemSourceCache = setmetatable({}, { __mode = "v" })
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Upgrade sources", function()
+		local entries = 0
+		for _ in pairs(ItemSourceCache) do entries = entries + 1 end
+		return entries, entries, "generated item-source objects"
+	end)
+end
 local function GetUpgrade(t, up)
 	local itemID = t.itemID
 	local upmodID = floor(up);
@@ -550,6 +557,9 @@ local function GetUpgrade(t, up)
 	return itemSource
 end
 api.GetUpgrade = GetUpgrade;
+app.AddEventHandler("OnMemoryCleanup", function()
+	wipe(ItemSourceCache)
+end)
 
 -- Returns the different and upgraded version of 't' (via 'up' field only)
 local function HasUpgrade(t)
@@ -654,7 +664,7 @@ local function UpdateUpgrades()
 	wipe(UpgradeSources)
 	-- Get all up entries
 	for up,refs in pairs(app.SearchForFieldContainer("up")) do
-		Runner.Run(UpdateUpgradeGroups, refs)
+		Runner.Run(UpdateUpgradeGroups, app.GetCachedFieldResults(refs, true))
 	end
 
 	-- Any re-try updates can try faster

--- a/src/Settings/Pages/Features - Audio.lua
+++ b/src/Settings/Pages/Features - Audio.lua
@@ -151,35 +151,62 @@ local textSoundpack = child:CreateTextLabel("|cffFFFFFF"..L.SOUNDPACK)
 textSoundpack:SetPoint("LEFT", headerCelebrations, 0, 0)
 textSoundpack:SetPoint("TOP", checkboxPlayDeathSound, "BOTTOM", 0, -8)
 
-local dropdownSoundpack = CreateFrame("Frame", "dropdownSoundpack", child, "UIDropDownMenuTemplate")
-dropdownSoundpack:SetPoint("TOPLEFT", textSoundpack, "BOTTOMLEFT", -15, 0)
-UIDropDownMenu_SetWidth(dropdownSoundpack, 270) -- Use in place of dropDown:SetWidth
+local function GetSortedSoundPackNames()
+	local soundPacks = {}
+	for _, soundPack in pairs(app.Audio:GetAllSoundPacks()) do
+		tinsert(soundPacks, soundPack.name)
+	end
+	table.sort(soundPacks)
+	return soundPacks
+end
 
--- Set the dropdown's current text to the active soundpack
-app.Audio:RegisterForSoundPackEvents(function(event, soundPack)
-	UIDropDownMenu_SetText(dropdownSoundpack, app.Audio:GetActiveSoundPack().name)
-end)
-
--- Change the active soundpack based on user selection
-local function WPDropDownDemo_OnClick(self, arg1)
-	app.Audio:ActivateSoundPack(arg1)
-	UIDropDownMenu_SetText(dropdownSoundpack, app.Audio:GetActiveSoundPack().name)
+local function SelectSoundPack(name)
+	app.Audio:ActivateSoundPack(name)
 	app.Audio:PlayFanfare()
 end
 
--- Populate the dropdown menu with all existing soundpacks
-function WPDropDownDemo_Menu(frame, level, menuList)
-	local soundPacks = {};
-	for i, soundPack in pairs(app.Audio:GetAllSoundPacks()) do
-		tinsert(soundPacks, soundPack.name);
-	end
-	table.sort(soundPacks);
+if app.IsRetail then
+	local dropdownSoundpack = CreateFrame("DropdownButton", nil, child, "WowStyle1DropdownTemplate")
+	dropdownSoundpack:SetPoint("TOPLEFT", textSoundpack, "BOTTOMLEFT", 0, -2)
+	dropdownSoundpack:SetWidth(270)
+	dropdownSoundpack:SetDefaultText(app.Audio:GetActiveSoundPack().name)
 
-	local info = UIDropDownMenu_CreateInfo()
-	info.func = WPDropDownDemo_OnClick
-	for i, name in ipairs(soundPacks) do
-		info.text, info.arg1 = name, name
-		UIDropDownMenu_AddButton(info)
+	local function IsSoundPackSelected(name)
+		return app.Audio:GetActiveSoundPack().name == name
 	end
+
+	dropdownSoundpack:SetupMenu(function(_, rootDescription)
+		for _, name in ipairs(GetSortedSoundPackNames()) do
+			rootDescription:CreateRadio(name, IsSoundPackSelected, SelectSoundPack, name)
+		end
+	end)
+
+	-- Refresh the selected text when another module changes the active pack.
+	app.Audio:RegisterForSoundPackEvents(function()
+		dropdownSoundpack:GenerateMenu()
+	end)
+else
+	-- Current Classic clients do not consistently expose Blizzard_Menu. Use a
+	-- standard button which cycles packs without requiring the Retail menu framework.
+	local soundPackButton = CreateFrame("Button", nil, child, "UIPanelButtonTemplate")
+	soundPackButton:SetPoint("TOPLEFT", textSoundpack, "BOTTOMLEFT", 0, -2)
+	soundPackButton:SetSize(270, 24)
+	soundPackButton:SetText(app.Audio:GetActiveSoundPack().name)
+	soundPackButton:SetScript("OnClick", function()
+		local soundPacks = GetSortedSoundPackNames()
+		local activeName = app.Audio:GetActiveSoundPack().name
+		local nextIndex = 1
+		for index, name in ipairs(soundPacks) do
+			if name == activeName then
+				nextIndex = index % #soundPacks + 1
+				break
+			end
+		end
+		if soundPacks[nextIndex] then
+			SelectSoundPack(soundPacks[nextIndex])
+		end
+	end)
+	app.Audio:RegisterForSoundPackEvents(function()
+		soundPackButton:SetText(app.Audio:GetActiveSoundPack().name)
+	end)
 end
-UIDropDownMenu_Initialize(dropdownSoundpack, WPDropDownDemo_Menu)

--- a/src/Settings/Pages/General.lua
+++ b/src/Settings/Pages/General.lua
@@ -177,7 +177,7 @@ local function presetStore()
 	settings:Set("PresetRestore", settingsTable)
 end
 
-local modeButton = CreateFrame("Button", nil, child, "UIDropDownMenuButtonScriptTemplate")
+local modeButton = CreateFrame("Button", nil, child)
 modeButton:SetSize(24, 24)
 modeButton:SetPoint("LEFT", headerMode, "RIGHT", 1, 0)
 modeButton:SetNormalTexture("Interface\\ChatFrame\\UI-ChatIcon-ScrollDown-Up")

--- a/src/Settings/Pages/Interface - Information.lua
+++ b/src/Settings/Pages/Interface - Information.lua
@@ -223,6 +223,86 @@ local KnownByIgnoredTypes = {
 	MountWithItem = true,
 }
 local knownBy = {};
+local UNKNOWN_RECIPE_OWNER_TEXT = "another character on this account";
+local APPEARANCE_KNOWN_ACCOUNT_TEXT = "Appearance known by a character on this account";
+
+-- Known-by tooltip results are requested repeatedly while hovering rows and links. Cache the
+-- account-character scan by generation instead of walking every character for every tooltip.
+-- Weak values allow Lua to reclaim entries under pressure, while explicit invalidation keeps
+-- profession and appearance scans immediately accurate.
+local RecipeKnownByCache = setmetatable({}, { __mode = "v" });
+local AppearanceKnownByCache = setmetatable({}, { __mode = "v" });
+local RecipeKnownByGeneration, AppearanceKnownByGeneration = 0, 0;
+
+app.InvalidateKnownByCache = function(kind)
+	if kind == "recipe" then
+		RecipeKnownByGeneration = RecipeKnownByGeneration + 1;
+	elseif kind == "appearance" then
+		AppearanceKnownByGeneration = AppearanceKnownByGeneration + 1;
+	else
+		RecipeKnownByGeneration = RecipeKnownByGeneration + 1;
+		AppearanceKnownByGeneration = AppearanceKnownByGeneration + 1;
+	end
+end
+
+local function GetRecipeKnownByInfo(recipeID)
+	local cached = RecipeKnownByCache[recipeID];
+	if cached and cached.generation == RecipeKnownByGeneration then return cached; end
+	local owners, seen = {}, {};
+	for guid,character in pairs(ATTCharacterData) do
+		local spells = character.Spells;
+		if spells and spells[recipeID] and not seen[guid] then
+			seen[guid] = true;
+			owners[#owners + 1] = character;
+		end
+	end
+	cached = {
+		generation = RecipeKnownByGeneration,
+		owners = owners,
+		accountFallback = #owners == 0 and app.IsAccountCached("Spells", recipeID) or false,
+	};
+	RecipeKnownByCache[recipeID] = cached;
+	return cached;
+end
+
+local function GetAppearanceKnownByInfo(sourceID)
+	local cached = AppearanceKnownByCache[sourceID];
+	if cached and cached.generation == AppearanceKnownByGeneration then return cached; end
+	local owners = {};
+	local isKnown = app.IsAppearanceKnown and app.IsAppearanceKnown(sourceID) or false;
+	if isKnown and app.GetAppearanceKnownCharacters then
+		app.GetAppearanceKnownCharacters(sourceID, owners);
+	end
+	cached = {
+		generation = AppearanceKnownByGeneration,
+		known = isKnown and true or false,
+		owners = owners,
+	};
+	AppearanceKnownByCache[sourceID] = cached;
+	return cached;
+end
+
+app.AddEventHandler("OnSavesUpdated", function()
+	app.InvalidateKnownByCache();
+end);
+app.AddEventHandler("OnMemoryCleanup", function()
+	wipe(RecipeKnownByCache);
+	wipe(AppearanceKnownByCache);
+end);
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Known-by tooltip ownership", function()
+		local entries, references = 0, 0;
+		for _,entry in pairs(RecipeKnownByCache) do
+			entries = entries + 1;
+			references = references + (entry.owners and #entry.owners or 0);
+		end
+		for _,entry in pairs(AppearanceKnownByCache) do
+			entries = entries + 1;
+			references = references + (entry.owners and #entry.owners or 0);
+		end
+		return entries, references, "cached recipe/appearance tooltip ownership";
+	end);
+end
 local function BuildKnownByInfoForKind(tooltipInfo, kind)
 	if #knownBy > 0 and kind then
 		app.Sort(knownBy, app.SortDefaults.name);
@@ -382,7 +462,44 @@ local function ProcessForCompletedBy(t, reference, tooltipInfo)
 	end
 end
 local function ProcessForKnownBy(t, reference, tooltipInfo)
-	-- This is to show which characters have this profession.
+	-- Recipes are tracked per-character in the Spells cache. Explicitly use recipeID
+	-- first since external item tooltips do not always resolve the virtual spellID field.
+	local recipeID = reference.recipeID
+	if recipeID then
+		local info = GetRecipeKnownByInfo(recipeID);
+		for i=1,#info.owners do tinsert(knownBy, info.owners[i]); end
+		-- Account cache can retain a learned recipe even if the original character
+		-- was removed, renamed, transferred, or has not refreshed professions yet.
+		if #knownBy == 0 and info.accountFallback then
+			tinsert(knownBy, { text = UNKNOWN_RECIPE_OWNER_TEXT });
+		end
+		BuildKnownByInfoForKind(tooltipInfo, L.KNOWN_BY);
+		return
+	end
+
+	-- Retail appearances are learned account-wide and Blizzard does not retain the
+	-- character which originally unlocked them. Report the reliable account state,
+	-- including appearances learned through a different source sharing the visual.
+	local sourceID = reference.sourceID;
+	if sourceID then
+		local info = GetAppearanceKnownByInfo(sourceID);
+		if info.known then
+			for i=1,#info.owners do tinsert(knownBy, info.owners[i]); end
+			if #knownBy > 0 then
+				BuildKnownByInfoForKind(tooltipInfo, L.KNOWN_BY)
+			else
+				tinsert(tooltipInfo, {
+					left = APPEARANCE_KNOWN_ACCOUNT_TEXT,
+					wrap = true,
+					color = app.Colors.TooltipDescription,
+				});
+			end
+		end
+		return
+	end
+
+	-- This is to show which characters have this profession or know another
+	-- character-specific spell/collectible.
 	local id = reference.knownByID or reference.spellID
 	if id then
 		if reference.key == "professionID" and app.IsClassic then	-- Apparently Retail doesn't use ActiveSkills
@@ -426,6 +543,10 @@ local function ProcessForKnownBy(t, reference, tooltipInfo)
 			BuildKnownByInfoForKind(tooltipInfo, L.KNOWN_BY);
 		end
 	end
+end
+if app.ProfileWrap then
+	ProcessForKnownBy = app.ProfileWrap("Tooltip.KnownBy", ProcessForKnownBy);
+	ProcessForCompletedBy = app.ProfileWrap("Tooltip.CompletedBy", ProcessForCompletedBy);
 end
 
 -- Specialization Requirements

--- a/src/Settings/Pages/Interface.lua
+++ b/src/Settings/Pages/Interface.lua
@@ -543,7 +543,7 @@ end,
 function(self)
 	settings:SetTooltipSetting("KnownBy", self:GetChecked())
 end)
-checkboxKnownBy:SetATTTooltip(L.KNOWN_BY_CHECKBOX_TOOLTIP)
+checkboxKnownBy:SetATTTooltip((L.KNOWN_BY_CHECKBOX_TOOLTIP or "") .. "\n\nAlso reports when an appearance is already known anywhere on the account.")
 checkboxKnownBy:AlignBelow(checkboxCompletedBy)
 
 local checkboxSpecializations = child:CreateCheckBox(L.SPEC_CHECKBOX,

--- a/src/UI/Minimap Button.lua
+++ b/src/UI/Minimap Button.lua
@@ -5,7 +5,14 @@ local appName, app = ...;
 local DESCRIPTION_SEPARATOR, L = app.DESCRIPTION_SEPARATOR, app.L;
 
 -- Global locals
-local math_floor = math.floor;
+local math_floor, math_atan, math_pi = math.floor, math.atan, math.pi;
+local function atan2(y, x)
+	if x > 0 then return math_atan(y / x); end
+	if x < 0 then return math_atan(y / x) + (y >= 0 and math_pi or -math_pi); end
+	if y > 0 then return math_pi * 0.5; end
+	if y < 0 then return math_pi * -0.5; end
+	return 0;
+end
 
 ---@class ATTGameTooltip
 local GameTooltip = GameTooltip;
@@ -117,8 +124,7 @@ local function CreateMinimapButton()
 		local mx, my = Minimap:GetCenter();
 		local px, py = GetCursorPosition();
 		local scale = Minimap:GetEffectiveScale();
-		---@diagnostic disable-next-line: deprecated
-		position = math.deg(math.atan2((py / scale) - my, (px / scale) - mx)) % 360;
+		position = math.deg(atan2((py / scale) - my, (px / scale) - mx)) % 360;
 		AllTheThingsSavedVariables.MinimapButtonAngle = position;
 		self:Raise();
 		self:update();

--- a/src/UI/Window Definitions.lua
+++ b/src/UI/Window Definitions.lua
@@ -2351,13 +2351,13 @@ local function BuildWindow(suffix)
 
 	-- Some Window functions should be triggered from ATT events
 	window:AddEventHandler("OnUpdateWindows", function(...)
-		window:Update(...)
+		window:QueueUpdate(...)
 	end, true)
 	window:AddEventHandler("OnRefreshWindows", function(...)
-		window:Refresh(...)
+		window:QueueRefresh(...)
 	end, true)
 	window:AddEventHandler("OnRedrawWindows", function()
-		window:Redraw()
+		window:QueueRedraw()
 	end, true)
 	window:AddEventHandler("OnWindowCreated", function()
 		-- ugh the sequencing of things is still so wacky. windows being created before settings exist is still happening
@@ -2635,6 +2635,46 @@ local function BuildWindow(suffix)
 	function window:Redraw()
 		-- app.PrintDebug(self.Suffix,":Redraw")
 		window:DefaultRedraw();
+	end
+
+	-- Global ATT events can request the same window operation several times in one frame
+	-- (collection updates, settings, and map changes often arrive together). Collapse them
+	-- into the strongest pending operation: Update > Refresh > Redraw. Direct/manual calls
+	-- remain immediate, preserving caller expectations.
+	local queuedWindowOperation, queuedWindowForce, queuedWindowTrigger = 0, nil, nil;
+	local function RunQueuedWindowOperation()
+		local operation, force, trigger = queuedWindowOperation, queuedWindowForce, queuedWindowTrigger;
+		queuedWindowOperation, queuedWindowForce, queuedWindowTrigger = 0, nil, nil;
+		if operation == 3 then
+			window:Update(force, trigger);
+		elseif operation == 2 then
+			window:Refresh();
+		elseif operation == 1 then
+			window:Redraw();
+		end
+	end
+	function window:QueueUpdate(force, trigger)
+		if queuedWindowOperation >= 3 and app.ProfileCount then app.ProfileCount("Window.CoalescedUpdate") end
+		queuedWindowOperation = 3;
+		queuedWindowForce = queuedWindowForce or force;
+		queuedWindowTrigger = queuedWindowTrigger or trigger;
+		Callback(RunQueuedWindowOperation);
+	end
+	function window:QueueRefresh()
+		if queuedWindowOperation >= 2 then
+			if app.ProfileCount then app.ProfileCount("Window.CoalescedRefresh") end
+		else
+			queuedWindowOperation = 2;
+		end
+		Callback(RunQueuedWindowOperation);
+	end
+	function window:QueueRedraw()
+		if queuedWindowOperation >= 1 then
+			if app.ProfileCount then app.ProfileCount("Window.CoalescedRedraw") end
+		else
+			queuedWindowOperation = 1;
+		end
+		Callback(RunQueuedWindowOperation);
 	end
 
 	-- Delayed call starts two nested coroutines so that calls can chain, if necessary.

--- a/src/UI/Windows/Achievements.lua
+++ b/src/UI/Windows/Achievements.lua
@@ -181,7 +181,7 @@ app:CreateWindow("Achievements", {
 				for i,matches in next,app.GetFieldContainer("achievementID") do
 					if not data.achievements[i] then
 						local mostAccessibleSource;
-						for j,o in ipairs(matches) do
+						for j,o in app.IterateCachedFieldResults(matches) do
 							if o.key == "achievementID" or o.key == "guildAchievementID" then
 								if GetRelativeValue(o, "_hqt") or GetRelativeValue(o, "u") == 1 or o.isStatistic then
 									data.achievements[i] = true;

--- a/src/UI/Windows/Find.lua
+++ b/src/UI/Windows/Find.lua
@@ -9,7 +9,7 @@ local ipairs, rawset, tostring, tinsert = ipairs, rawset, tostring, tinsert;
 -- WoW API Cache
 local GetItemInfo = app.WOWAPI.GetItemInfo;
 local GetItemID = app.WOWAPI.GetItemID;
-local GetItemSpell = GetItemSpell;
+local GetItemSpell = app.WOWAPI.GetItemSpell;
 local C_Item_GetItemInventoryTypeByID = C_Item and C_Item.GetItemInventoryTypeByID;
 
 -- Implementation

--- a/src/UI/Windows/List.lua
+++ b/src/UI/Windows/List.lua
@@ -53,7 +53,7 @@ local function BuildDataFromCache()
 	-- collect valid id values
 	local ValidKeys, cacheID = {}, nil;
 	for id,groups in pairs(app.GetRawFieldContainer(DataType) or app.EmptyTable) do
-		for index,o in ipairs(groups) do
+		for index,o in app.IterateCachedFieldResults(groups) do
 			cacheID = tonumber(o.modItemID or o[DataType]) or 0;
 			if cacheID ~= 0 then ValidKeys[cacheID] = true; end
 		end

--- a/src/UI/Windows/Local List.lua
+++ b/src/UI/Windows/Local List.lua
@@ -22,8 +22,10 @@ function LocalMapFilter(group)
 	end
 end
 local CachedLocalMapData = setmetatable({}, {
+	__mode = "v",
 	__index = function(cachedLocalMapData, mapID)
 		if mapID then
+			local requestedMapID = mapID;
 			__currentMapID = mapID;
 			local results = app:BuildSearchFilteredResponse(app:GetDatabaseRoot().g, LocalMapFilter);
 			if results and #results > 0 then
@@ -49,12 +51,26 @@ local CachedLocalMapData = setmetatable({}, {
 					print("Path: ", mapPath);
 				end
 				print("Please report this to the ATT Discord! Thanks! ", app.Version);
-				cachedLocalMapData[mapID] = false;
+				cachedLocalMapData[requestedMapID] = false;
 				return false;
 			end
 		end
 	end
 });
+
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Local List maps", function()
+		local entries, resultRoots = 0, 0
+		for _,results in pairs(CachedLocalMapData) do
+			entries = entries + 1
+			if type(results) == "table" then resultRoots = resultRoots + #results end
+		end
+		return entries, resultRoots, "maps / result roots"
+	end)
+end
+app.AddEventHandler("OnMemoryCleanup", function()
+	wipe(CachedLocalMapData)
+end)
 
 -- Implementation
 app:CreateWindow("Local List", {

--- a/src/UI/Windows/Maps.lua
+++ b/src/UI/Windows/Maps.lua
@@ -41,7 +41,7 @@ app:CreateWindow("Maps", {
 								mapInfo = C_Map_GetMapInfo(mapID),
 								collectible = true,
 								collected = true,
-								statistic = tostring(#cachedMaps),
+								statistic = tostring(app.GetCachedFieldCount(cachedMaps)),
 							});
 							mapObject.sym = {{ "select", "mapID", mapID }};
 							mapsByID[mapID] = mapObject;

--- a/src/UI/Windows/Mini List.lua
+++ b/src/UI/Windows/Mini List.lua
@@ -155,6 +155,8 @@ local RetailMapDataStyleMetatable = {
 			end
 			local rootMaps = rootMap and rootMap.maps
 			if rootMaps then
+				-- Never append sub-map entries directly into the central field index.
+				results = ArrayAppend({}, results)
 				local subresults, subMapID
 				for i=1,#rootMaps do
 					subMapID = rootMaps[i]
@@ -391,11 +393,21 @@ local CachedMapData = setmetatable({}, RetailMapDataStyleMetatable);
 app.GetCachedDataForMapID = function(mapID)
 	return CachedMapData[mapID];
 end
-app.AddEventHandler("OnSettingsNeedsRefresh", function()
-	-- if settings change that require a refresh, wipe cached maps
-	-- TODO: technically, we might only need to completely wipe if the active Fillers are changed
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Mini List maps", function()
+		local entries, children = 0, 0
+		for _,mapData in pairs(CachedMapData) do
+			entries = entries + 1
+			if type(mapData) == "table" and type(mapData.g) == "table" then children = children + #mapData.g end
+		end
+		return entries, children, "maps / immediate child groups"
+	end)
+end
+local function WipeMiniListCache()
 	wipe(CachedMapData)
-end)
+end
+app.AddEventHandler("OnSettingsNeedsRefresh", WipeMiniListCache)
+app.AddEventHandler("OnMemoryCleanup", WipeMiniListCache)
 local function TrySwapFromCache(self)
 	local now = GetTimePreciseSec()
 	-- window to keep cached maps/not re-build & update them
@@ -472,6 +484,22 @@ app:CreateWindow("MiniList", {
 		-- don't allow bad values
 		mapID = tonumber(mapID) or 0
 		-- app.PrintDebug("SetMapID",mapID,force)
+		if not force and mapID == self.mapID then
+			self:Show();
+			return;
+		end
+		-- Multiple child/subzone map IDs can point at the exact same consolidated Mini List
+		-- object. Update the effective map ID and reuse the existing rows instead of
+		-- detaching, filling, and updating an identical tree.
+		local equivalentMapData = not force and rawget(CachedMapData, mapID);
+		if self.data and equivalentMapData == self.data then
+			self.mapID = mapID;
+			self.data.mapID = mapID;
+			self:Show();
+			self:QueueRefresh();
+			if app.ProfileCount then app.ProfileCount("MiniList.EquivalentMapReuse") end
+			return;
+		end
 		if force and mapID ~= 0 then
 			CachedMapData[mapID] = nil
 			self.mapID = nil

--- a/src/UI/Windows/Missing Quests.lua
+++ b/src/UI/Windows/Missing Quests.lua
@@ -79,9 +79,9 @@ app:CreateWindow("Missing Quests", {
 				end
 
 				for id,questData in pairs(app.GetFieldContainer("questID")) do
-					if not MissingQuestsFromQuestieDict[id] and not QuestieDB.QuestPointers[id] and #questData > 1 and questData[1].u ~= 1 then
+					if not MissingQuestsFromQuestieDict[id] and not QuestieDB.QuestPointers[id] and app.GetCachedFieldCount(questData) > 1 and app.GetFirstCachedFieldResult(questData).u ~= 1 then
 						local shouldAdd = true;
-						for i,quest in ipairs(questData) do
+						for i,quest in app.IterateCachedFieldResults(questData) do
 							if not quest.parent or GetRelativeValue(quest, "u") == 1 or GetRelativeValue(quest, "_hqt") then
 								shouldAdd = false;
 							end

--- a/src/UI/Windows/Professions.lua
+++ b/src/UI/Windows/Professions.lua
@@ -91,8 +91,9 @@ function app:CreateDynamicProfessionCategory(name, commands, professionID, speci
 							local recipes = {};
 							for spellID,sources in pairs(app.GetFieldContainer("spellID")) do
 								if associatedSpellIDs[spellID] and not recipes[spellID] then
-									local count = #sources;
+									local count = app.GetCachedFieldCount(sources);
 									if count > 0 then
+										sources = app.GetCachedFieldResults(sources, true);
 										if count > 1 then
 											-- Find the most accessible version of the thing.
 											app.Sort(sources, app.SortDefaults.Accessibility);

--- a/src/UI/Windows/Random.lua
+++ b/src/UI/Windows/Random.lua
@@ -14,10 +14,22 @@ local SearchFilter;
 
 -- when changing settings, we need the random cache to be cleared since it's determined based on search
 -- results with specific settings
-local searchCache = {};
-app.AddEventHandler("OnRecalculate_NewSettings", function()
+local searchCache = setmetatable({}, { __mode = "v" });
+if app.RegisterMemoryCacheStats then
+	app.RegisterMemoryCacheStats("Random searches", function()
+		local entries, results = 0, 0
+		for _,values in pairs(searchCache) do
+			entries = entries + 1
+			if type(values) == "table" then results = results + #values end
+		end
+		return entries, results, "search modes / result references"
+	end)
+end
+local function WipeRandomSearchCache()
 	wipe(searchCache)
-end)
+end
+app.AddEventHandler("OnRecalculate_NewSettings", WipeRandomSearchCache)
+app.AddEventHandler("OnMemoryCleanup", WipeRandomSearchCache)
 local function SearchRecursively(group, results, func, field)
 	if group.visible and not (group.saved or group.collected) then
 		if group.g then

--- a/src/UI/Windows/Retail/Tradeskills.lua
+++ b/src/UI/Windows/Retail/Tradeskills.lua
@@ -335,7 +335,14 @@ app:CreateWindow("Tradeskills", {
 						app.PrintDebug("No Missing Recipes!")
 					end
 				end
+				-- Opening a profession is the authoritative per-character recipe scan.
+				-- Invalidate cached tooltip ownership even when no account-wide recipe was new,
+				-- because the character attribution may have changed.
+				if app.InvalidateKnownByCache then app.InvalidateKnownByCache("recipe") end
 			end
+		end
+		if app.ProfileWrap then
+			UpdateLearnedRecipes = app.ProfileWrap("Profession.UpdateLearnedRecipes", UpdateLearnedRecipes)
 		end
 		-- Custom SearchValueCriteria for requireSkill searches
 		local criteria = {

--- a/src/UI/Windows/Tradeskills.lua
+++ b/src/UI/Windows/Tradeskills.lua
@@ -211,7 +211,7 @@ app:CreateWindow("Tradeskills", {
 								end
 								if not skillCache[spellID] then
 									app.print("Missing " .. craftName .. " (Spell ID #" .. spellID .. ") in ATT Database. Please report it!");
-									skillCache[spellID] = { {} };
+									skillCache[spellID] = {};
 								end
 							else
 								app.print("Missing " .. craftName .. " spellID in ATT Database. Please report it!");
@@ -271,7 +271,7 @@ app:CreateWindow("Tradeskills", {
 
 								if not skillCache[spellID] then
 									app.print("Missing " .. (skillName or "[??]") .. " (Spell ID #" .. spellID .. ") in ATT Database. Please report it!");
-									skillCache[spellID] = { {} };
+									skillCache[spellID] = {};
 								end
 							else
 								app.print("Missing " .. (skillName or "[??]") .. " spellID in ATT Database. Please report it!");

--- a/src/UI/Windows/World Quests.lua
+++ b/src/UI/Windows/World Quests.lua
@@ -50,7 +50,7 @@ app:CreateWindow("WorldQuests", {
 		local MapContainer = app.GetFieldContainer("mapID");
 		local function CreateMapWithStyle(id)
 			local mapObject = app.CreateMap(id, { progress = 0, total = 0 });
-			for _,data in ipairs(MapContainer[id]) do
+			for _,data in app.IterateCachedFieldResults(MapContainer[id]) do
 				if data.mapID and data.icon then
 					mapObject.name = data.name;
 					mapObject.icon = data.icon;


### PR DESCRIPTION
Ref: https://github.com/dsypher2/AllTheThings/commits/master/

AllTheThings 5.2.6 - Midnight 12.0.7 performance optimization r8

R8 PERFORMANCE OPTIMIZATION
- Added opt-in runtime profiling commands for searches, symlinks, collection refreshes, profession scans, tooltip ownership, memory maintenance, and window pipelines.
- Coalesced repeated global window update/refresh/redraw requests into one strongest operation per window per frame. Direct and manual window calls remain immediate.
- Mini List now reuses the current consolidated data tree when a child/subzone map ID resolves to the same cached location data, avoiding an identical fill/update pass.
- Added generation-based weak caches for recipe and appearance Known By tooltip data.
- Recipe ownership is invalidated after the authoritative profession-open scan, including scans where no newly learned account recipe was found.
- Appearance ownership is invalidated on transmog source add/remove events.
- Automatic login and zone cleanup now use bounded incremental garbage-collection steps over multiple frames. Manual cleanup and index rebuild remain synchronous.

R8 COMMANDS
- /att profile start
- /att profile stop
- /att profile report
- /att profile report all
- /att profile reset
- /att profile status

R8 VALIDATION
- All Lua files passed Lua 5.4 syntax loading.
- Runtime tests passed for profiler multi-return preservation, automatic incremental-GC completion, window-operation coalescing, and ownership-cache invalidation.
- All XML files parsed successfully and ZIP integrity was verified.

AllTheThings 5.2.6 - Midnight 12.0.7 adaptive memory diagnostics r6

R6 additions
- Adds /att memory detail and /att memory detail all.
- Reports the largest key-search fields, class-property caches, and rebuildable cache entry/reference counts.
- Adds a second automatic cleanup 60 seconds after the first startup cleanup.
- Makes zone cleanup adaptive: transient caches and garbage collection run only after ATT grows 30 MB above the last clean baseline.
- Search-index compaction after zone changes runs only when the index mutation generation changed.
- Preserves combat deferral and rapid-zone debounce.

AllTheThings 5.2.6 - Midnight 12.0.7 zone/index memory optimization r5

R5 MEMORY MAINTENANCE
- Added an automatic memory cleanup 12 seconds after ATT resolves a genuinely different zone/map, allowing Mini List and delayed zone scans to finish first.
- Zone cleanup is debounced across rapid map changes and postponed during combat.
- Each zone cleanup releases transient caches, compacts duplicate/invalid entries in the live key search index, and runs Lua garbage collection.
- Routine zone cleanup is silent unless it releases at least 10 MB.
- Added /att memory index clean for an index-only in-place compaction.
- Added /att memory index rebuild for a full reconstruction of all field-container hash tables and shared-key arrays from the currently indexed live objects.
- The rebuild does not rerun ATT field converters or mutate database objects, which avoids duplicate custom-map and dynamic-data side effects.
- /att memory now reports the last automatic zone-clean result.

R5 SAFETY
- Automatic zone maintenance preserves field-container table identity.
- Full index rebuild is manual-only and blocked during combat.
- Battle-pet alert, merchant API, compact-index, and class-cache fixes are retained.

AllTheThings 5.2.6 - Midnight 12.0.7 memory optimization r4

R4 MEMORY OPTIMIZATION
- Reworked ATT's central field index to store single-match IDs directly instead of retaining a separate one-element Lua array for every indexed ID.
- Shared-key IDs still use normal arrays and preserve search ordering/results.
- Added compact-cache compatibility helpers and updated every internal direct field-container consumer to handle singleton and shared-key entries safely.
- Prevented class property lookups with no value/default from retaining empty per-ID cache tables.
- Added cleanup of empty class-property cache entries and weak, collectible singleton result wrappers.
- Added automatic one-time transient-cache cleanup after the first collection refresh completes, delayed when the player is in combat.
- /att memory now reports compact search-index and class-cache statistics.
- /att memory clean still performs the full transient cache cleanup and GC.

R4 VALIDATION
- 301 Lua files parsed with zero syntax errors.
- 10 XML files parsed with zero errors.
- Compact cache functional tests passed for singleton, multi-result, sorting, modItemID/itemID fallback, iteration, and cleanup behavior.
- Class-property cache tests passed for no-allocation reads, side-effect cache preservation, and empty-entry pruning.
- Memory command and automatic cleanup scheduling tests passed.

AllTheThings 5.2.6 - Midnight 12.0.7 compatibility patch r2

R2 HOTFIX
- Restored the valid Retail global APIs GetMerchantNumItems and GetMerchantItemLink.
- Removed invalid references to nonexistent C_MerchantFrame.GetNumItems and C_MerchantFrame.GetItemLink.
- Fixes the Debugger.lua load failure: API GetMerchantNumItems not available.

AllTheThings 5.2.6 - Midnight 12.0.7 Compatibility Patch r1 ================================================================

Build date: 2026-06-29
Base package: AllTheThings 5.2.6 (official current release dated 2026-06-28)
Retail target: World of Warcraft Midnight 12.0.7
Retail Interface: 120007

Primary correction
------------------
- Fixed repeated "added to collection" reports for already-owned Midnight battle pets and companion pets when entering a zone or refreshing the ATT mini window.
- Battle-pet collection getters are now read-only. Rendering a row can no longer call SetThingCollected or generate a collection alert.
- RefreshBattlePets now checks every ATT-known species with C_PetJournal.GetNumCollectedInfo before updating saved caches.
- C_PetJournal.GetPetInfoByIndex is retained only for supplemental pet GUID to species lookup; it is no longer trusted as an authoritative ownership scan.

Midnight API modernization
---------------------------
- Replaced Retail spellbook iteration with C_SpellBook APIs and current Enum.SpellBookSpellBank / Enum.SpellBookItemType values.
- Isolated legacy spell, item, chat, merchant, party, specialization, and addon API fallbacks to non-Retail clients so Midnight does not evaluate them.
- Added current wrappers for C_AddOns.GetAddOnMetadata, C_Item.GetDetailedItemLevelInfo, and C_Item.GetItemSpell.
- Replaced UIDropDownMenu sound-pack UI with DropdownButton, WowStyle1DropdownTemplate, SetupMenu, and radio descriptions.
- Removed the obsolete UIDropDownMenuButtonScriptTemplate dependency from the General settings menu button.
- Replaced deprecated math.atan2 use with a compatible local atan2 helper.
- Removed stale deprecation suppressions around APIs that are current in 12.0.7.

Files changed
-------------
- AllTheThings.toc
- src/base.lua
- src/WoW API Wrappers.lua
- src/Classes/BattlePet.lua
- src/Classes/Spell.lua
- src/Classes/Item.Retail.lua
- src/Classes/Gear Sets.lua
- src/Classes/Transmog.lua
- src/Expansions/Legion.lua
- src/Modules/Tooltip.lua
- src/Settings/Pages/Features - Audio.lua
- src/Settings/Pages/General.lua
- src/UI/Minimap Button.lua
- src/UI/Windows/Find.lua

Validation performed
--------------------
- Parsed every Lua source file in the package with Lua 5.4 syntax validation.
- Scanned the complete package for APIs removed/deprecated in Retail 12.0.1, 12.0.5, and 12.0.7: no active Midnight-path references remain.
- Scanned for UIDropDownMenu and math.atan2: no references remain.
- Verified the ZIP contains AllTheThings/AllTheThings.toc and passes archive integrity testing.

Compatibility note
------------------
Classic-only legacy fallbacks remain behind explicit non-Retail branches where needed by the official multi-client package. They are not evaluated on Midnight.

Limitations
-----------
This build received static source, syntax, API, load-order, and archive checks. It could not be launched inside the World of Warcraft client here, so an in-game smoke test is still recommended after installation.

r7 - Account Known Tooltip Restoration
- Restored explicit per-character Known By reporting for recipes.
- Added account-cache fallback when a recipe owner character cannot be identified.
- Added account-wide appearance-known tooltip reporting.
- Restored memory-efficient per-character appearance-owner tracking for newly acquired visuals and legacy source-owner data.
- Appearance checks include alternate item sources sharing the same visual.
- Blizzard does not expose the character that originally unlocked a Retail appearance, so appearance tooltips report the reliable account-wide state instead of inventing a character name.