### PR TITLE
All Vainilla flavors are using the anniversary patch 1.15.8

### DIFF
--- a/.contrib/Parser/.config/classic/01 - Classic Era.config
+++ b/.contrib/Parser/.config/classic/01 - Classic Era.config
@@ -10,7 +10,7 @@
     "db-relative": "Vanilla/",
     "DataPhase": "CLASSIC",
 	"DataRequirements": "not C_Seasons or C_Seasons.GetActiveSeason() ~= 2",
-    "DataPatch": [ 1, 15, 6, 58658 ],
+    "DataPatch": [ 1, 15, 8, 67156 ],
     "PreProcessorTags": [
         "ANYCLASSIC",
 		"CLASSIC",

--- a/.contrib/Parser/.config/classic/01 - Classic SOD.config
+++ b/.contrib/Parser/.config/classic/01 - Classic SOD.config
@@ -7,7 +7,7 @@
     "db-relative": "VanillaSOD/",
     "DataPhase": "SEASON_OF_DISCOVERY",
 	"DataRequirements": "C_Seasons and C_Seasons.GetActiveSeason() == 2",
-    "DataPatch": [ 1, 15, 7, 99999 ],
+    "DataPatch": [ 1, 15, 8, 67156 ],
     "PreProcessorTags": [
         "ANYCLASSIC",
 		"CLASSIC",

--- a/.contrib/Parser/lib/Constants/Timelines.lua
+++ b/.contrib/Parser/lib/Constants/Timelines.lua
@@ -188,7 +188,6 @@ REMOVED_1_15_6 = "removed 1.15.6.58844";					-- World of Warcraft Classic 1.15.6
 CREATED_1_15_7 = "created 1.15.7.60141";					-- World of Warcraft Classic 1.15.7 launch on April 8th, 2025
 ADDED_1_15_7 = "added 1.15.7.60141";						-- World of Warcraft Classic 1.15.7 launch on April 8th, 2025
 REMOVED_1_15_7 = "removed 1.15.7.60141";					-- World of Warcraft Classic 1.15.7 launch on April 8th, 2025
--- ANNIVERSARY --
 CREATED_1_15_8 = "created 1.15.8.63829";					-- World of Warcraft Classic Anniversary 1.15.8 launch on October 21st, 2025
 ADDED_1_15_8 = "added 1.15.8.63829";						-- World of Warcraft Classic Anniversary 1.15.8 launch on October 21st, 2025
 REMOVED_1_15_8 = "removed 1.15.8.63829";					-- World of Warcraft Classic Anniversary 1.15.8 launch on October 21st, 2025


### PR DESCRIPTION
<img width="1347" height="987" alt="imagen" src="https://github.com/user-attachments/assets/29333abc-06f4-4723-a2cd-0b623b3d9dcf" />
