### PR TITLE
[Classic] Class Trial 90 not available in MOP Classic yet

### DIFF
--- a/.contrib/Parser/DATAS/11 - Character/Class Trials/05 - Mists of Pandaria/Level 90 Class Trials.lua
+++ b/.contrib/Parser/DATAS/11 - Character/Class Trials/05 - Mists of Pandaria/Level 90 Class Trials.lua
@@ -2,12 +2,12 @@
 --    C H A R A C T E R   M O D U L E    --
 -------------------------------------------
 
+-- #if NOT ANYCLASSIC
 root(ROOTS.Character, n(CLASS_TRIAL, {
-	expansion(EXPANSION.MOP,bubbleDown({ ["u"] = REAL_MONEY, ["timeline"] = { ADDED_5_4_7, REMOVED_6_0_2 } }, {
-		header(HEADERS.Achievement, 6193, applyclassicphase(MOP_PHASE_SIEGE_OF_ORGRIMMAR, {
+	expansion(EXPANSION.MOP, bubbleDown({ ["u"] = REAL_MONEY, ["timeline"] = { ADDED_5_4_7, REMOVED_6_0_2 } }, {
+		header(HEADERS.Achievement, 6193, {
 			-- Note: [As of patch 6.0.1 Level 90 Boost does not reward this gear anymore]
 			["description"] = "These were obtained by creating a Level 90 Class Trial for each class and specialization.",
-			["lvl"] = 90,
 			["groups"] = {
 				cl(DEATHKNIGHT, {
 					cl(DEATHKNIGHT, UNHOLY, {
@@ -409,6 +409,7 @@ root(ROOTS.Character, n(CLASS_TRIAL, {
 					}),
 				}),
 			},
-		})),
+		}),
 	})),
 }));
+-- #endif


### PR DESCRIPTION
and fix real money status