### PR TITLE
[CLASSIC]: Call in the Cavalry: restrict criteria to the races that can use them

### DIFF
--- a/.contrib/Parser/DATAS/08 - PvP/00 Achievements.lua
+++ b/.contrib/Parser/DATAS/08 - PvP/00 Achievements.lua
@@ -134,7 +134,46 @@ root(ROOTS.PVP, pvp(n(ACHIEVEMENTS, {
 	ach(19417, {		-- Brawlroom Blitzer
 		["timeline"] = { ADDED_10_2_0 },
 	}),
-	applyclassicphase(PHASE_TWO, ach(727)),	-- Call in the Cavalry (automated)
+	applyclassicphase(PHASE_TWO, ach(727, {	-- Call in the Cavalry (automated)
+		-- Each criteria is automated from the War Mount it is earned by, but the restrictions that
+		-- Item carries are not, so every mount in the achievement counts against every character.
+		["groups"] = {
+			-- The original War Mounts need the matching riding skill, which is why the Items
+			-- themselves are race restricted. 2.0.1 replaced them with unrestricted versions.
+			-- #if BEFORE 2.0.1
+			crit(6213, {	-- Black Battlestrider (18243)
+				["races"] = { DWARF, GNOME },
+			}),
+			crit(6214, {	-- Black War Kodo (18247)
+				["races"] = HORDE_ONLY,
+			}),
+			crit(6215, {	-- Black War Ram (18244)
+				["races"] = ALLIANCE_ONLY,
+			}),
+			crit(6216, {	-- Black War Steed (18241)
+				["races"] = ALLIANCE_ONLY,
+			}),
+			crit(6217, {	-- Black War Wolf (18245)
+				["races"] = HORDE_ONLY,
+			}),
+			crit(6219, {	-- Black War Tiger (18242)
+				["races"] = ALLIANCE_ONLY,
+			}),
+			crit(6220, {	-- Black War Raptor (18246)
+				["races"] = { ORC, UNDEAD, TROLL },
+			}),
+			crit(6222, {	-- Red Skeletal Warhorse (18248)
+				["races"] = { ORC, UNDEAD, TROLL },
+			}),
+			-- #endif
+			crit(6221, {	-- Swift Warstrider (34129)
+				["timeline"] = { ADDED_2_3_0 },
+			}),
+			crit(6218, {	-- Black War Elekk (35906)
+				["timeline"] = { ADDED_2_4_0 },
+			}),
+		},
+	})),
 	applyclassicphase(WRATH_PHASE_ONE, ach(908, {	-- Call to Arms! (Alliance)
 		["timeline"] = { ADDED_3_0_2 },
 		["races"] = ALLIANCE_ONLY,


### PR DESCRIPTION
### Problem
The ten criteria of achievement 727 are automated from the War Mount each one is earned by,
and the automation copies the provider Item but not the restrictions that Item carries. So
every mount in the achievement counts against every character.

On a Human that is seven criteria which can never be completed: the four Horde mounts, the
Gnome mechanostrider, and two mounts from an expansion the client does not have.

### Fix
The race lists are already in ATT — on the vendor items in Stormwind City and Orgrimmar, and
in the item DB (18243 is {DWARF, GNOME}, 18246/18248 are {ORC, UNDEAD, TROLL}, and so on).
This puts the same values on the criteria.

`races` rather than `r`, so the existing filters do the right thing per scope: character
scope drops the Battlestrider for a Human, faction scope keeps it (a Gnome on the account
could get it), account scope filters nothing.

Fenced `#if BEFORE 2.0.1`, because 2.0.1 replaced these items with unrestricted versions and
applying the restriction later would be the mirror-image bug. Swift Warstrider and Black War
Elekk get the timeline of the mounts they are earned by.

### Testing
Verified in game on Classic Era (Alliance Human): the achievement goes from 10 criteria to
3 — Black War Steed, Black War Tiger, Black War Ram.